### PR TITLE
Modified PX4 SoC Estimation

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -253,12 +253,12 @@ void Battery::estimateStateOfCharge(const float voltage_v, const float current_a
 					_state_of_charge = 1.0;
 					below_max = false;
 				}
-				if (cell_voltage <= SOCLookup[9].OCVoltage) {
+				if (cell_voltage <= SOCLookup[10].OCVoltage) {
 					_state_of_charge = 0.0;
 					above_min = false;
 				}
 				if (above_min && below_max) {
-					for (int i = 0; i < 10; i++) {
+					for (int i = 0; i < 11; i++) {
 						float voltage_key = SOCLookup[i].OCVoltage;
 						if (cell_voltage > voltage_key) {
 							const float volt1 = SOCLookup[i].OCVoltage;

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -188,105 +188,128 @@ void Battery::sumDischarged(const hrt_abstime &timestamp, float current_a)
 
 void Battery::estimateStateOfCharge(const float voltage_v, const float current_a, const float throttle)
 {
-	// remaining battery capacity based on voltage
-	float cell_voltage = voltage_v / _params.n_cells;
 
-	// correct battery voltage locally for load drop to avoid estimation fluctuations
-	if (_params.r_internal >= 0.f) {
-		cell_voltage += _params.r_internal * current_a;
+	bool sees_coulomb_counting_only = true;
+	// Sees.ai modification coulomb_counting_only
+	// Set to 'true' for Sees behaviour:
+	// SoC relies solely on mAh discharged.
+	//
+	// Set to 'false' for default PX4 behaviour:
+	// SoC is based on whichever of the two options below that provides the lower value:
+	// - A combination of discharge and Voltage based estimation (relies more on voltage at lower voltages).
+	// - Just on discharge.
 
-	} else {
-		// assume linear relation between throttle and voltage drop
-		cell_voltage += throttle * _params.v_load_drop;
-	}
 
-	_state_of_charge_volt_based = math::gradual(cell_voltage, _params.v_empty, _params.v_charged, 0.f, 1.f);
+	// -------------------------------------------
+	// If bool is true, do sees desired behaviour
+	// -------------------------------------------
 
-	// choose which quantity we're using for final reporting
-	if (_params.capacity > 0.f && _battery_initialized) {
-		// if battery capacity is known, fuse voltage measurement with used capacity
-		// The lower the voltage the more adjust the estimate with it to avoid deep discharge
-		const float weight_v = 3e-4f * (1 - _state_of_charge_volt_based);
-		_state_of_charge = (1 - weight_v) * _state_of_charge + weight_v * _state_of_charge_volt_based;
-		// directly apply current capacity slope calculated using current
-		_state_of_charge -= _discharged_mah_loop / _params.capacity;
-		_state_of_charge = math::max(_state_of_charge, 0.f);
+	if (sees_coulomb_counting_only) {
 
-		const float state_of_charge_current_based = math::max(1.f - _discharged_mah / _params.capacity, 0.f);
+		// This ensures the cell voltage is derived from the filtered voltage and corrects for any voltage load drop as PX4 uses the raw voltage values.
 
-		bool sees_coulomb_counting_only = true;
-		// Sees.ai modification coulomb_counting_only
+		cell_voltage_filtered = _voltage_filter_v.getState();
+		cell_voltage_filtered /= _params.n_cells;
+		cell_voltage_filtered_load += _params.r_internal * current_a;
 
-		// Set to 'true' for Sees behaviour:
-		// SoC relies solely on mAh discharged.
-		//
-		// Set to 'false' for default PX4 behaviour:
-		// SoC is based on whichever of the two options below that provides the lower value:
-		// - A combination of discharge and Voltage based estimation (relies more on voltage at lower voltages).
-		// - Just on discharge.
-
-		if (sees_coulomb_counting_only) {
-
-			if(first_run || ((hrt_absolute_time() - first_run_time) < 1'000'000)){
-				struct Lookup {
-					float OCVoltage;
-					float SOC;
-				};
-
+		// Derives initial SoC Estimation from the voltage. A 15 second timer is included to allow voltage to settle whilst components initialise.
+		if(first_run || ((hrt_absolute_time() - first_run_time) < 15'000'000)){
+			struct Lookup {
+				float OCVoltage;
+				float SOC;
+			};
 				Lookup SOCLookup[] {
-					{4.17, 100.0},
-					{4.09, 89.5},
-					{3.99, 79.1},
-					{3.93, 68.6},
-					{3.87, 58.2},
-					{3.82, 47.7},
-					{3.79, 37.3},
-					{3.77, 26.8},
-					{3.73, 16.4},
-					{3.69, 5.9},
-					{3.50, 0.0}
-				};
-				bool above_min = true;
-				bool below_max = true;
+				{4.17, 100.0},
+				{4.09, 89.5},
+				{3.99, 79.1},
+				{3.93, 68.6},
+				{3.87, 58.2},
+				{3.82, 47.7},
+				{3.79, 37.3},
+				{3.77, 26.8},
+				{3.73, 16.4},
+				{3.69, 5.9},
+				{3.50, 0.0}
+			};
+			bool above_min = true;
+			bool below_max = true;
 
-				if (cell_voltage >= SOCLookup[0].OCVoltage) {
-					_state_of_charge = 1.0;
-					below_max = false;
-				}
-				if (cell_voltage <= SOCLookup[10].OCVoltage) {
-					_state_of_charge = 0.0;
-					above_min = false;
-				}
-				if (above_min && below_max) {
-					for (int i = 0; i < 10; i++) {
-						float voltage_key = SOCLookup[i].OCVoltage;
-						if (cell_voltage > voltage_key) {
-							const float volt1 = SOCLookup[i].OCVoltage;
-							const float soc1 = SOCLookup[i].SOC;
-							const float volt2 = SOCLookup[i+1].OCVoltage;
-							const float soc2 = SOCLookup[i+1].SOC;
-							soc_initial = (soc1 + (soc2 - soc1) * (cell_voltage - volt1) / (volt2 - volt1))/100;
-							break;
-						}
+
+
+			if (cell_voltage_filtered >= SOCLookup[0].OCVoltage) {
+				_state_of_charge = 1.0;
+				below_max = false;
+			}
+			if (cell_voltage_filtered <= SOCLookup[10].OCVoltage) {
+				_state_of_charge = 0.0;
+				above_min = false;
+			}
+			if (above_min && below_max) {
+				for (int i = 0; i < 10; i++) {
+					float voltage_key = SOCLookup[i].OCVoltage;
+					if (cell_voltage_filtered > voltage_key) {
+						const float volt1 = SOCLookup[i].OCVoltage;
+						const float soc1 = SOCLookup[i].SOC;
+						const float volt2 = SOCLookup[i+1].OCVoltage;
+						const float soc2 = SOCLookup[i+1].SOC;
+						soc_initial = (soc1 + (soc2 - soc1) * (cell_voltage_filtered - volt1) / (volt2 - volt1))/100;
+						break;
 					}
 				}
+			}
+			if (first_run) {
+				first_run_time = hrt_absolute_time();
 				first_run = false;
 			}
-
-			// CURRENT SOC CALC
-			_state_of_charge = soc_initial - (_discharged_mah/_params.capacity);
-			// Cell Voltage Monitor Warnings
-			if (cell_voltage < float(3.4) && (hrt_absolute_time() - sees_warning_last > 10'000'000)) {
-				mavlink_log_critical(&_mavlink_log_pub, "Cell Voltage Critical - %fV. Land Immediately!", double(cell_voltage));
-				sees_warning_last = hrt_absolute_time();
-			}
 		}
-		else {
-			_state_of_charge = math::min(state_of_charge_current_based, _state_of_charge);
+
+		// CURRENT SOC CALC
+		_state_of_charge = soc_initial - (_discharged_mah/_params.capacity);
+
+		// Voltage Monitor warning - Coulomb counting won't catch cell failures so we add a warning if cell voltage drops to a critical level (3.4V).
+		// This is derived from.........
+		if (cell_voltage_filtered < float(3.4) && (hrt_absolute_time() - sees_warning_last > 10'000'000)) {
+			mavlink_log_critical(&_mavlink_log_pub, "Warning, Critical cell voltage %fV. Land Immediately!", double(cell_voltage_filtered_load));
 		}
 	}
+
+
+	// -----------------------------
+	// Else do PX4 Default Behaviour
+	// -----------------------------
+
 	else {
-		_state_of_charge = _state_of_charge_volt_based;
+		// remaining battery capacity based on voltage
+		float cell_voltage = voltage_v / _params.n_cells;
+
+		// correct battery voltage locally for load drop to avoid estimation fluctuations
+		if (_params.r_internal >= 0.f) {
+			cell_voltage += _params.r_internal * current_a;
+
+		} else {
+			// assume linear relation between throttle and voltage drop
+			cell_voltage += throttle * _params.v_load_drop;
+		}
+
+		_state_of_charge_volt_based = math::gradual(cell_voltage, _params.v_empty, _params.v_charged, 0.f, 1.f);
+
+		// choose which quantity we're using for final reporting
+		if (_params.capacity > 0.f && _battery_initialized) {
+			// if battery capacity is known, fuse voltage measurement with used capacity
+			// The lower the voltage the more adjust the estimate with it to avoid deep discharge
+			const float weight_v = 3e-4f * (1 - _state_of_charge_volt_based);
+			_state_of_charge = (1 - weight_v) * _state_of_charge + weight_v * _state_of_charge_volt_based;
+			// directly apply current capacity slope calculated using current
+			_state_of_charge -= _discharged_mah_loop / _params.capacity;
+			_state_of_charge = math::max(_state_of_charge, 0.f);
+
+			const float state_of_charge_current_based = math::max(1.f - _discharged_mah / _params.capacity, 0.f);
+
+			_state_of_charge = math::min(state_of_charge_current_based, _state_of_charge);
+		}
+		else {
+			_state_of_charge = _state_of_charge_volt_based;
+		}
 	}
 }
 

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -201,4 +201,7 @@ private:
 	float _scale{1.f};
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
+
+	bool first_run = true;
+	float soc_initial{0};
 };

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -206,6 +206,8 @@ private:
 
 	float first_run_time;
 	bool first_run{true};
+	float cell_voltage_filtered;
+	float cell_voltage_filtered_load;
 	float soc_initial{0};
 	float sees_warning_last;
 	orb_advert_t _mavlink_log_pub{nullptr};

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -56,6 +56,8 @@
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/battery_status.h>
 
+#include <systemlib/mavlink_log.h>
+
 /**
  * BatteryBase is a base class for any type of battery.
  *
@@ -202,6 +204,9 @@ private:
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 
-	bool first_run = true;
+	float first_run_time;
+	bool first_run{true};
 	float soc_initial{0};
+	float sees_warning_last;
+	orb_advert_t _mavlink_log_pub{nullptr};
 };


### PR DESCRIPTION
The original PX4 firmware uses a hybrid of voltage monitoring and coulomb counting to determine the battery pack's state of charge.
However, this was heavily weighted towards estimating SoC based on voltage (as this is the safer option). A number of factors can affect cell voltage, such as temperature, making this not the most reliable method. Additionally, PX4 assumes a very linear relationship between voltage and SoC which is not the case.

Instead, the firmware has been modified to better align with the SI2 implementation.
The LookUp table for SoC based on voltage has been copied from SI2 to provide an initial estimation, before switching to coulomb counting to determine the state of charge based on the observed discharge throughout the flight.

In the event of average cell voltage dropping to a critical level (signifying cell failure), the pilot will be repeatedly warned and advised to land. 