### PR TITLE
Backport Dual RTK heading for HolyBro-F9P from PX4 v1.13.0 to v1.12.1_dev branch.

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -129,6 +129,7 @@ set(msg_files
 	sensor_combined.msg
 	sensor_correction.msg
 	sensor_gps.msg
+	sensor_gnss_relative.msg
 	sensor_gyro.msg
 	sensor_gyro_fft.msg
 	sensor_gyro_fifo.msg

--- a/msg/sensor_gnss_relative.msg
+++ b/msg/sensor_gnss_relative.msg
@@ -1,0 +1,30 @@
+# GNSS relative positioning information in NED frame. The NED frame is defined as the local topological system at the reference station.
+
+uint64 timestamp                  # time since system start (microseconds)
+uint64 timestamp_sample           # time since system start (microseconds)
+
+uint32 device_id                  # unique device ID for the sensor that does not change between power cycles
+
+uint64 time_utc_usec              # Timestamp (microseconds, UTC), this is the timestamp which comes from the gps module. It might be unavailable right after cold start, indicated by a value of 0
+
+uint16 reference_station_id       # Reference Station ID
+
+float32[3] position               # GPS NED relative position vector (m)
+float32[3] position_accuracy      # Accuracy of relative position (m)
+
+float32 heading                   # Heading of the relative position vector (radians)
+float32 heading_accuracy          # Accuracy of heading of the relative position vector (radians)
+
+float32 position_length
+float32 accuracy_length
+
+bool gnss_fix_ok                  # GNSS valid fix (i.e within DOP & accuracy masks)
+bool differential_solution        # differential corrections were applied
+bool relative_position_valid
+bool carrier_solution_floating    # carrier phase range solution with floating ambiguities
+bool carrier_solution_fixed       # carrier phase range solution with fixed ambiguities
+bool moving_base_mode             # if the receiver is operating in moving base mode
+bool reference_position_miss      # extrapolated reference position was used to compute moving base solution this epoch
+bool reference_observations_miss  # extrapolated reference observations were used to compute moving base solution this epoch
+bool heading_valid
+bool relative_position_normalized # the components of the relative position vector (including the high-precision parts) are normalized

--- a/msg/sensor_gps.msg
+++ b/msg/sensor_gps.msg
@@ -38,3 +38,4 @@ uint8 satellites_used		# Number of satellites used
 
 float32 heading			# heading angle of XYZ body frame rel to NED. Set to NaN if not available and updated (used for dual antenna GPS), (rad, [-PI, PI])
 float32 heading_offset		# heading offset of dual antenna array in body frame. Set to NaN if not applicable. (rad, [-PI, PI])
+float32 heading_accuracy	# heading accuracy (rad, [0, 2PI])

--- a/src/drivers/gps/definitions.h
+++ b/src/drivers/gps/definitions.h
@@ -43,6 +43,7 @@
 #include <px4_platform_common/defines.h>
 #include <uORB/topics/satellite_info.h>
 #include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/sensor_gnss_relative.h>
 
 #define GPS_INFO(...) PX4_INFO(__VA_ARGS__)
 #define GPS_WARN(...) PX4_WARN(__VA_ARGS__)

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -370,6 +370,10 @@ int GPS::callback(GPSCallbackType type, void *data1, int data2, void *user)
 		/* not used */
 		break;
 
+	case GPSCallbackType::gotRelativePositionMessage:
+		/* not used */
+		break;
+
 	case GPSCallbackType::surveyInStatus:
 		/* not used */
 		break;

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -85,14 +85,17 @@ private:
 			msg.h_acc = gps.eph * 1e3f;              // position uncertainty in mm
 			msg.v_acc = gps.epv * 1e3f;              // altitude uncertainty in mm
 			msg.vel_acc = gps.s_variance_m_s * 1e3f; // speed uncertainty in mm
-			msg.hdg_acc = math::degrees(gps.c_variance_rad) * 1e5f; // Heading / track uncertainty in degE5
 
 			if (PX4_ISFINITE(gps.heading)) {
 				if (fabsf(gps.heading) < FLT_EPSILON) {
 					msg.yaw = 36000; // Use 36000 for north.
 
 				} else {
-					msg.yaw = math::degrees(gps.heading) * 100.f; // centidegrees
+					msg.yaw = math::degrees(matrix::wrap_2pi(gps.heading)) * 100.0f; // centidegrees
+				}
+
+				if (PX4_ISFINITE(gps.heading_accuracy)) {
+					msg.hdg_acc = math::degrees(gps.heading_accuracy) * 1e5f; // Heading / track uncertainty in degE5
 				}
 			}
 


### PR DESCRIPTION
Reference PX4 Autopilot v1.13.0 branch of GPS code reference used for backport: https://github.com/PX4/PX4-Autopilot/tree/v1.13.0.