### PR TITLE
Added OB_Manual_Control to CubeOrange Cmake module list

### DIFF
--- a/boards/cubepilot/cubeorange/default.cmake
+++ b/boards/cubepilot/cubeorange/default.cmake
@@ -89,6 +89,7 @@ px4_add_board(
 		#uuv_pos_control
 		vmount
 		vtol_att_control
+		ob_manual_control
 	SYSTEMCMDS
 		bl_update
 		dmesg


### PR DESCRIPTION
Small change to add ob_manual_control to the module list in the CubeOrange cmake file.
Shouldn't affect anything else.