### PR TITLE
Changing vehicle_angular_acceleration publish trigger

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -115,9 +115,9 @@ bool VehicleAngularVelocity::UpdateSampleRate()
 			_reset_filters = true;
 			_filter_sample_rate_hz = sample_rate_hz;
 
-			if (_param_imu_gyro_ratemax.get() > 0.f) {
+			if (_param_imu_integ_rate.get() > 0.f) {
 				// determine number of sensor samples that will get closest to the desired rate
-				const float configured_interval_us = 1e6f / _param_imu_gyro_ratemax.get();
+				const float configured_interval_us = 1e6f / _param_imu_integ_rate.get();
 				const float publish_interval_us = 1e6f / publish_rate_hz;
 
 				const uint8_t samples = roundf(configured_interval_us / publish_interval_us);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -182,7 +182,7 @@ private:
 		(ParamFloat<px4::params::IMU_GYRO_CUTOFF>) _param_imu_gyro_cutoff,
 		(ParamFloat<px4::params::IMU_GYRO_NF_FREQ>) _param_imu_gyro_nf_freq,
 		(ParamFloat<px4::params::IMU_GYRO_NF_BW>) _param_imu_gyro_nf_bw,
-		(ParamInt<px4::params::IMU_GYRO_RATEMAX>) _param_imu_gyro_ratemax,
+		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate,
 		(ParamFloat<px4::params::IMU_DGYRO_CUTOFF>) _param_imu_dgyro_cutoff
 	)
 };


### PR DESCRIPTION
We have changed the vehicle_angular_acceleration module to publish according to imu_integ_rate (previously imu_gyro_ratemax - which looks like a bug as this will have no effect)

Further detail can be found in Tech Note **TN22.20 PX4 IMU Timing** linked below.
https://www.notion.so/seesai/9fff57c476af493fb2d1553b29735289?v=e09536fba7174554982c7b3320ea07f4&p=c3c7742aa5b045d5a37b8ebd4a6e0856&pm=s