### PR TITLE
Dp pos ctl d button

### DIFF
--- a/src/modules/ob_manual_control/OBManualControl.cpp
+++ b/src/modules/ob_manual_control/OBManualControl.cpp
@@ -325,6 +325,7 @@ void OBManualControl::UseRCSetpoints(manual_control_switches_s *manual_control_s
 		_position_control_rc_request_received = (manual_control_switches_rc->mode_slot != _mode_slot_prev) &&
 							(_state == MAV_CONTROL);
 		_mode_slot_prev = manual_control_switches_rc->mode_slot;
+
 	} else {
 		PX4_INFO("Multi Channel mode");
 		// Mode selection set by multiple Channels, only interested in these:

--- a/src/modules/ob_manual_control/OBManualControl.cpp
+++ b/src/modules/ob_manual_control/OBManualControl.cpp
@@ -217,13 +217,13 @@ void OBManualControl::run()
 					_manual_control_switches_sub.publish(_manual_control_switches);
 					_manual_control_setpoint_sub.publish(_manual_control_setpoint);
 
-					// _position_override should always be false when in RC_CONTROL.
-					_position_override = false;
+					// _position_override_rc_request should always be false when in RC_CONTROL (we dont need to change _state).
+					_position_control_rc_request_received = false;
 					break;
 				}
 
 			case MAV_CONTROL: {
-					if (switch_toggled || _position_override) {
+					if (switch_toggled || _position_control_rc_request_received) {
 						//PX4_INFO("Switching to RC control");
 						mavlink_log_critical(&_mavlink_log_pub, "Switching to RC control");
 						_state = RC_CONTROL;
@@ -322,8 +322,8 @@ void OBManualControl::UseRCSetpoints(manual_control_switches_s *manual_control_s
 		// This makes the switch to PositionCtl register at a higher level in rc_update. If we are in RC control already, then the D button
 		// works as normal by triggering PositionCtl whilst remaining in RC_CONTROL.
 		// Note: the _state == MAV_CONTROL is not needed as UseRCSetpoints is only called when in MAV_CONTROL already, but kept as a sanity check.
-		_position_override =  	(manual_control_switches_rc->mode_slot != _mode_slot_prev) &&
-					(_state == MAV_CONTROL);
+		_position_control_rc_request_received = (manual_control_switches_rc->mode_slot != _mode_slot_prev) &&
+							(_state == MAV_CONTROL);
 		_mode_slot_prev = manual_control_switches_rc->mode_slot;
 	} else {
 		PX4_INFO("Multi Channel mode");

--- a/src/modules/ob_manual_control/OBManualControl.cpp
+++ b/src/modules/ob_manual_control/OBManualControl.cpp
@@ -219,6 +219,7 @@ void OBManualControl::run()
 
 					// _position_override_rc_request should always be false when in RC_CONTROL (we dont need to change _state).
 					_position_control_rc_request_received = false;
+					_mode_slot_prev = _manual_control_switches_rc.mode_slot;
 					break;
 				}
 
@@ -239,6 +240,7 @@ void OBManualControl::run()
 
 					_manual_control_switches_sub.publish(_manual_control_switches);
 					_manual_control_setpoint_sub.publish(_manual_control_setpoint);
+					_mode_slot_prev = _manual_control_switches_rc.mode_slot;
 					break;
 				}
 			}
@@ -324,7 +326,6 @@ void OBManualControl::UseRCSetpoints(manual_control_switches_s *manual_control_s
 		// Note: the _state == MAV_CONTROL is not needed as UseRCSetpoints is only called when in MAV_CONTROL already, but kept as a sanity check.
 		_position_control_rc_request_received = (manual_control_switches_rc->mode_slot != _mode_slot_prev) &&
 							(_state == MAV_CONTROL);
-		_mode_slot_prev = manual_control_switches_rc->mode_slot;
 
 	} else {
 		PX4_INFO("Multi Channel mode");

--- a/src/modules/ob_manual_control/OBManualControl.cpp
+++ b/src/modules/ob_manual_control/OBManualControl.cpp
@@ -328,8 +328,6 @@ void OBManualControl::UseRCSetpoints(manual_control_switches_s *manual_control_s
 			_position_control_rc_request_received = (manual_control_switches_rc->mode_slot != _mode_slot_prev) &&
 								(_state == MAV_CONTROL);
 		}
-		//TODO: Check that it's MODE_SLOT_NONE and not SWITCH_POS_NONE
-
 
 	} else {
 		PX4_INFO("Multi Channel mode");

--- a/src/modules/ob_manual_control/OBManualControl.cpp
+++ b/src/modules/ob_manual_control/OBManualControl.cpp
@@ -324,8 +324,12 @@ void OBManualControl::UseRCSetpoints(manual_control_switches_s *manual_control_s
 		// This makes the switch to PositionCtl register at a higher level in rc_update. If we are in RC control already, then the D button
 		// works as normal by triggering PositionCtl whilst remaining in RC_CONTROL.
 		// Note: the _state == MAV_CONTROL is not needed as UseRCSetpoints is only called when in MAV_CONTROL already, but kept as a sanity check.
-		_position_control_rc_request_received = (manual_control_switches_rc->mode_slot != _mode_slot_prev) &&
-							(_state == MAV_CONTROL);
+		if (_mode_slot_prev != manual_control_switches_s::MODE_SLOT_NONE) {
+			_position_control_rc_request_received = (manual_control_switches_rc->mode_slot != _mode_slot_prev) &&
+								(_state == MAV_CONTROL);
+		}
+		//TODO: Check that it's MODE_SLOT_NONE and not SWITCH_POS_NONE
+
 
 	} else {
 		PX4_INFO("Multi Channel mode");

--- a/src/modules/ob_manual_control/OBManualControl.hpp
+++ b/src/modules/ob_manual_control/OBManualControl.hpp
@@ -105,6 +105,8 @@ private:
 
 	bool kill_prev{false};
 
+	uint8_t _mode_slot_prev{};
+	bool _position_override{false};
 
 
 };

--- a/src/modules/ob_manual_control/OBManualControl.hpp
+++ b/src/modules/ob_manual_control/OBManualControl.hpp
@@ -106,7 +106,7 @@ private:
 	bool kill_prev{false};
 
 	uint8_t _mode_slot_prev{};
-	bool _position_override{false};
+	bool _position_control_rc_request_received {false};	/**< true when drone is in Mav Joystick control but request to Position flight mode is received via RC channel */
 
 
 };


### PR DESCRIPTION
This modification has been made to rectify the problem linked below:
https://seesai.atlassian.net/jira/software/c/projects/S1/boards/25?modal=detail&selectedIssue=S1-2972&assignee=62160e7c6b7e24006a7a4573

In this, a QGC crash rendered the D button on the Herelink useless as it relied on requesting Position mode by sending a mavlink message.
Instead, we have mapped D to be a radio switch (through Herelink settings) which toggles the Single Channel Flight Mode feature on PX4. However, the radio switch isn't registered when in Mav Joystick control (due to the same issue that we've previously had with Kill Switch).
This pull requests fixes this by:
- When Flight Mode value changes (when D is pressed), if in Mav Joystick control revert back to RC control
- PX4 will now register the radio switch trigger at a higher level in rc_update.cpp and successfully switch to Position Mode.