### PR TITLE
ICM20948 backport

### DIFF
--- a/platforms/common/include/px4_platform_common/atomic.h
+++ b/platforms/common/include/px4_platform_common/atomic.h
@@ -58,6 +58,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if defined(__PX4_NUTTX)
+# include <nuttx/irq.h>
+#endif // __PX4_NUTTX
+
 namespace px4
 {
 
@@ -66,11 +70,11 @@ class atomic
 {
 public:
 
-#ifdef __PX4_NUTTX
+#if defined(__PX4_POSIX)
 	// Ensure that all operations are lock-free, so that 'atomic' can be used from
 	// IRQ handlers. This might not be required everywhere though.
 	static_assert(__atomic_always_lock_free(sizeof(T), 0), "atomic is not lock-free for the given type T");
-#endif
+#endif // __PX4_POSIX
 
 	atomic() = default;
 	explicit atomic(T value) : _value(value) {}
@@ -80,11 +84,19 @@ public:
 	 */
 	inline T load() const
 	{
-#ifdef __PX4_QURT
-		return _value;
-#else
-		return __atomic_load_n(&_value, __ATOMIC_SEQ_CST);
-#endif
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			T val = _value;
+			leave_critical_section(flags);
+			return val;
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_load_n(&_value, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -92,11 +104,18 @@ public:
 	 */
 	inline void store(T value)
 	{
-#ifdef __PX4_QURT
-		_value = value;
-#else
-		__atomic_store(&_value, &value, __ATOMIC_SEQ_CST);
-#endif
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			_value = value;
+			leave_critical_section(flags);
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			__atomic_store(&_value, &value, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -105,12 +124,19 @@ public:
 	 */
 	inline T fetch_add(T num)
 	{
-#ifdef __PX4_QURT
-		// TODO: fix
-		return _value++;
-#else
-		return __atomic_fetch_add(&_value, num, __ATOMIC_SEQ_CST);
-#endif
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			T ret = _value++;
+			leave_critical_section(flags);
+			return ret;
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_fetch_add(&_value, num, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -119,7 +145,19 @@ public:
 	 */
 	inline T fetch_sub(T num)
 	{
-		return __atomic_fetch_sub(&_value, num, __ATOMIC_SEQ_CST);
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			T ret = _value--;
+			leave_critical_section(flags);
+			return ret;
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_fetch_sub(&_value, num, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -128,7 +166,20 @@ public:
 	 */
 	inline T fetch_and(T num)
 	{
-		return __atomic_fetch_and(&_value, num, __ATOMIC_SEQ_CST);
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			T val = _value;
+			_value &= num;
+			leave_critical_section(flags);
+			return val;
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_fetch_and(&_value, num, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -137,7 +188,20 @@ public:
 	 */
 	inline T fetch_xor(T num)
 	{
-		return __atomic_fetch_xor(&_value, num, __ATOMIC_SEQ_CST);
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			T val = _value;
+			_value ^= num;
+			leave_critical_section(flags);
+			return val;
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_fetch_xor(&_value, num, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -146,7 +210,20 @@ public:
 	 */
 	inline T fetch_or(T num)
 	{
-		return __atomic_fetch_or(&_value, num, __ATOMIC_SEQ_CST);
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			T val = _value;
+			_value |= num;
+			leave_critical_section(flags);
+			return val;
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_fetch_or(&_value, num, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -155,7 +232,20 @@ public:
 	 */
 	inline T fetch_nand(T num)
 	{
-		return __atomic_fetch_nand(&_value, num, __ATOMIC_SEQ_CST);
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+			T ret = _value;
+			_value = ~(_value & num);
+			leave_critical_section(flags);
+			return ret;
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_fetch_nand(&_value, num, __ATOMIC_SEQ_CST);
+		}
 	}
 
 	/**
@@ -168,17 +258,31 @@ public:
 	 */
 	inline bool compare_exchange(T *expected, T desired)
 	{
-		return __atomic_compare_exchange(&_value, expected, &desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+#if defined(__PX4_NUTTX)
+
+		if (!__atomic_always_lock_free(sizeof(T), 0)) {
+			irqstate_t flags = enter_critical_section();
+
+			if (_value == *expected) {
+				_value = desired;
+				leave_critical_section(flags);
+				return true;
+
+			} else {
+				*expected = _value;
+				leave_critical_section(flags);
+				return false;
+			}
+
+		} else
+#endif // __PX4_NUTTX
+		{
+			return __atomic_compare_exchange(&_value, expected, &desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+		}
 	}
 
 private:
-#ifdef __PX4_QURT
-	// It seems that __atomic_store  and __atomic_load are not supported on Qurt,
-	// so the best that we can do is to use volatile.
-	volatile T _value{};
-#else
 	T _value {};
-#endif
 };
 
 using atomic_int = atomic<int>;

--- a/src/drivers/imu/invensense/icm20948/ICM20948.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,7 +50,7 @@ ICM20948::ICM20948(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Ro
 	_px4_accel(get_device_id(), rotation),
 	_px4_gyro(get_device_id(), rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 
@@ -135,14 +135,27 @@ void ICM20948::print_status()
 
 int ICM20948::probe()
 {
-	const uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
+	for (int i = 0; i < 3; i++) {
+		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
-	if (whoami != WHOAMI) {
-		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-		return PX4_ERROR;
+		if (whoami == WHOAMI) {
+			return PX4_OK;
+
+		} else {
+			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
+
+			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
+			int bank = reg_bank_sel >> 4;
+
+			if (bank >= 1 && bank <= 3) {
+				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
+				// force bank selection and retry
+				SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
+			}
+		}
 	}
 
-	return PX4_OK;
+	return PX4_ERROR;
 }
 
 void ICM20948::RunImpl()
@@ -229,9 +242,16 @@ void ICM20948::RunImpl()
 		break;
 
 	case STATE::FIFO_READ: {
+			hrt_abstime timestamp_sample = now;
+
 			if (_data_ready_interrupt_enabled) {
-				// scheduled from interrupt if _drdy_fifo_read_samples was set
-				if (_drdy_fifo_read_samples.fetch_and(0) != _fifo_gyro_samples) {
+				// scheduled from interrupt if _drdy_timestamp_sample was set as expected
+				const hrt_abstime drdy_timestamp_sample = _drdy_timestamp_sample.fetch_and(0);
+
+				if ((now - drdy_timestamp_sample) < _fifo_empty_interval_us) {
+					timestamp_sample = drdy_timestamp_sample;
+
+				} else {
 					perf_count(_drdy_missed_perf);
 				}
 
@@ -252,16 +272,30 @@ void ICM20948::RunImpl()
 
 			} else {
 				// FIFO count (size in bytes) should be a multiple of the FIFO::DATA structure
-				const uint8_t samples = (fifo_count / sizeof(FIFO::DATA) / SAMPLES_PER_TRANSFER) *
-							SAMPLES_PER_TRANSFER; // round down to nearest
+				uint8_t samples = fifo_count / sizeof(FIFO::DATA);
 
-				if (samples > FIFO_MAX_SAMPLES) {
-					// not technically an overflow, but more samples than we expected or can publish
-					FIFOReset();
-					perf_count(_fifo_overflow_perf);
+				if (samples > _fifo_gyro_samples) {
+					// grab desired number of samples, but reschedule next cycle sooner
+					int extra_samples = samples - _fifo_gyro_samples;
+					samples = _fifo_gyro_samples;
 
-				} else if (samples >= 1) {
-					if (FIFORead(now, samples)) {
+					if (_fifo_gyro_samples > extra_samples) {
+						// reschedule to run when a total of _fifo_gyro_samples should be available in the FIFO
+						const uint32_t reschedule_delay_us = (_fifo_gyro_samples - extra_samples) * static_cast<int>(FIFO_SAMPLE_DT);
+						ScheduleOnInterval(_fifo_empty_interval_us, reschedule_delay_us);
+
+					} else {
+						// otherwise reschedule to run immediately
+						ScheduleOnInterval(_fifo_empty_interval_us);
+					}
+
+				} else if (samples < _fifo_gyro_samples) {
+					// reschedule next cycle to catch the desired number of samples
+					ScheduleOnInterval(_fifo_empty_interval_us, (_fifo_gyro_samples - samples) * static_cast<int>(FIFO_SAMPLE_DT));
+				}
+
+				if (samples == _fifo_gyro_samples) {
+					if (FIFORead(timestamp_sample, samples)) {
 						success = true;
 
 						if (_failure_count > 0) {
@@ -378,9 +412,9 @@ void ICM20948::ConfigureSampleRate(int sample_rate)
 	_fifo_empty_interval_us = _fifo_gyro_samples * (1e6f / GYRO_RATE);
 }
 
-void ICM20948::SelectRegisterBank(enum REG_BANK_SEL_BIT bank)
+void ICM20948::SelectRegisterBank(enum REG_BANK_SEL_BIT bank, bool force)
 {
-	if (bank != _last_register_bank) {
+	if (bank != _last_register_bank || force) {
 		// select BANK_0
 		uint8_t cmd_bank_sel[2] {};
 		cmd_bank_sel[0] = static_cast<uint8_t>(Register::BANK_0::REG_BANK_SEL);
@@ -441,13 +475,10 @@ int ICM20948::DataReadyInterruptCallback(int irq, void *context, void *arg)
 
 void ICM20948::DataReady()
 {
-	uint32_t expected = 0;
-
 	// at least the required number of samples in the FIFO
-	if (((_drdy_count.fetch_add(1) + 1) >= _fifo_gyro_samples)
-	    && _drdy_fifo_read_samples.compare_exchange(&expected, _fifo_gyro_samples)) {
-
-		_drdy_count.store(0);
+	if (++_drdy_count >= _fifo_gyro_samples) {
+		_drdy_timestamp_sample.store(hrt_absolute_time());
+		_drdy_count -= _fifo_gyro_samples;
 		ScheduleNow();
 	}
 }
@@ -597,8 +628,8 @@ void ICM20948::FIFOReset()
 	RegisterClearBits(Register::BANK_0::FIFO_RST, FIFO_RST_BIT::FIFO_RESET);
 
 	// reset while FIFO is disabled
-	_drdy_count.store(0);
-	_drdy_fifo_read_samples.store(0);
+	_drdy_count = 0;
+	_drdy_timestamp_sample.store(0);
 }
 
 static bool fifo_accel_equal(const FIFO::DATA &f0, const FIFO::DATA &f1)

--- a/src/drivers/imu/invensense/icm20948/ICM20948.hpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,12 +76,12 @@ private:
 
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{1e6f / 9000.f};
-	static constexpr uint32_t SAMPLES_PER_TRANSFER{2};                   // ensure at least 1 new accel sample per transfer
+	static constexpr int32_t SAMPLES_PER_TRANSFER{2};                    // ensure at least 1 new accel sample per transfer
 	static constexpr float GYRO_RATE{1e6f / FIFO_SAMPLE_DT};             // 9000 Hz gyro
 	static constexpr float ACCEL_RATE{GYRO_RATE / SAMPLES_PER_TRANSFER}; // 4500 Hz accel
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr uint32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {
@@ -120,7 +120,7 @@ private:
 	void ConfigureGyro();
 	void ConfigureSampleRate(int sample_rate);
 
-	void SelectRegisterBank(enum REG_BANK_SEL_BIT bank);
+	void SelectRegisterBank(enum REG_BANK_SEL_BIT bank, bool force = false);
 	void SelectRegisterBank(Register::BANK_0 reg) { SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0); }
 	void SelectRegisterBank(Register::BANK_2 reg) { SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_2); }
 	void SelectRegisterBank(Register::BANK_3 reg) { SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_3); }
@@ -172,8 +172,8 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<uint32_t> _drdy_fifo_read_samples{0};
-	px4::atomic<uint32_t> _drdy_count{0};
+	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {
@@ -184,7 +184,7 @@ private:
 	} _state{STATE::RESET};
 
 	uint16_t _fifo_empty_interval_us{1250}; // default 1250 us / 800 Hz transfer interval
-	uint32_t _fifo_gyro_samples{static_cast<uint32_t>(_fifo_empty_interval_us / (1000000 / GYRO_RATE))};
+	int32_t _fifo_gyro_samples{static_cast<int32_t>(_fifo_empty_interval_us / (1000000 / GYRO_RATE))};
 
 	uint8_t _checked_register_bank0{0};
 	static constexpr uint8_t size_register_bank0_cfg{6};

--- a/src/drivers/imu/invensense/icm20948/ICM20948_AK09916.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_AK09916.cpp
@@ -51,7 +51,6 @@ ICM20948_AK09916::ICM20948_AK09916(ICM20948 &icm20948, enum Rotation rotation) :
 	_px4_mag(icm20948.get_device_id(), rotation)
 {
 	_px4_mag.set_device_type(DRV_MAG_DEVTYPE_AK09916);
-	_px4_mag.set_external(icm20948.external());
 
 	// mag resolution is 1.5 milli Gauss per bit (0.15 μT/LSB)
 	_px4_mag.set_scale(1.5e-3f);

--- a/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.cpp
@@ -85,14 +85,27 @@ void ICM20948_I2C_Passthrough::print_status()
 
 int ICM20948_I2C_Passthrough::probe()
 {
-	const uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
+	for (int i = 0; i < 3; i++) {
+		uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
 
-	if (whoami != WHOAMI) {
-		DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
-		return PX4_ERROR;
+		if (whoami == WHOAMI) {
+			return PX4_OK;
+
+		} else {
+			DEVICE_DEBUG("unexpected WHO_AM_I 0x%02x", whoami);
+
+			uint8_t reg_bank_sel = RegisterRead(Register::BANK_0::REG_BANK_SEL);
+			int bank = reg_bank_sel >> 4;
+
+			if (bank >= 1 && bank <= 3) {
+				DEVICE_DEBUG("incorrect register bank for WHO_AM_I REG_BANK_SEL:0x%02x, bank:%d", reg_bank_sel, bank);
+				// force bank selection and retry
+				SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0, true);
+			}
+		}
 	}
 
-	return PX4_OK;
+	return PX4_ERROR;
 }
 
 void ICM20948_I2C_Passthrough::RunImpl()
@@ -181,9 +194,9 @@ void ICM20948_I2C_Passthrough::RunImpl()
 	}
 }
 
-void ICM20948_I2C_Passthrough::SelectRegisterBank(enum REG_BANK_SEL_BIT bank)
+void ICM20948_I2C_Passthrough::SelectRegisterBank(enum REG_BANK_SEL_BIT bank, bool force)
 {
-	if (bank != _last_register_bank) {
+	if (bank != _last_register_bank || force) {
 		// select BANK_0
 		uint8_t cmd_bank_sel[2];
 		cmd_bank_sel[0] = static_cast<uint8_t>(Register::BANK_0::REG_BANK_SEL);

--- a/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.hpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.hpp
@@ -78,7 +78,7 @@ private:
 
 	bool Configure();
 
-	void SelectRegisterBank(enum REG_BANK_SEL_BIT bank);
+	void SelectRegisterBank(enum REG_BANK_SEL_BIT bank, bool force = false);
 	void SelectRegisterBank(Register::BANK_0 reg) { SelectRegisterBank(REG_BANK_SEL_BIT::USER_BANK_0); }
 
 	template <typename T> bool RegisterCheck(const T &reg_cfg);


### PR DESCRIPTION
Backported the driver for one of the Cube Orange IMUs (ICM20948) from PX4 v1.13.0 as there were errors in data resulting from the old driver.
The aforementioned issue is described here:
https://www.notion.so/seesai/TN22-24-Sensor-Dropout-Cube-Orange-Tiree-2-e0e7d38708984910968dbde5c5546732#45188949562b4ef18118ff7011f43131