### PR TITLE
Dp gps updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,10 +26,6 @@
 	path = boards/atlflight/cmake_hexagon
 	url = https://github.com/PX4/cmake_hexagon.git
 	branch = px4
-[submodule "src/drivers/gps/devices"]
-	path = src/drivers/gps/devices
-	url = https://github.com/PX4/PX4-GPSDrivers.git
-	branch = master
 [submodule "src/modules/micrortps_bridge/micro-CDR"]
 	path = src/modules/micrortps_bridge/micro-CDR
 	url = https://github.com/PX4/Micro-CDR.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -66,7 +66,3 @@
 [submodule "src/lib/crypto/monocypher"]
 	path = src/lib/crypto/monocypher
 	url = https://github.com/PX4/Monocypher.git
-[submodule "src/drivers/gps/devices"]
-	path = src/drivers/gps/devices
-	url = git@github.com:SEESAI/PX4-GPSDrivers.git
-	branch = 6534b05_dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 [submodule "src/lib/crypto/monocypher"]
 	path = src/lib/crypto/monocypher
 	url = https://github.com/PX4/Monocypher.git
+[submodule "src/drivers/gps/devices"]
+	path = src/drivers/gps/devices
+	url = https://github.com/SEESAI/PX4-GPSDrivers.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,7 @@
 [submodule "src/lib/crypto/monocypher"]
 	path = src/lib/crypto/monocypher
 	url = https://github.com/PX4/Monocypher.git
+[submodule "src/drivers/gps/devices"]
+	path = src/drivers/gps/devices
+	url = git@github.com:SEESAI/PX4-GPSDrivers.git
+	branch = 6534b05_dev

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -848,9 +848,7 @@ GPS::run()
 			if (ubx_mode == GPSDriverUBX::UBXMode::RoverWithMovingBase) {
 				/* The MB rover will wait as long as possible to compute a navigation solution,
 				 * possibly lowering the navigation rate all the way to 1 Hz while doing so. */
-				//
-				// Sees.ai reduced timeout to 2.5Hz
-				receive_timeout = TIMEOUT_2_5Hz;
+				receive_timeout = receive_timeout;
 			}
 
 			while ((helper_ret = _helper->receive(receive_timeout)) > 0 && !should_exit()) {
@@ -910,6 +908,8 @@ GPS::run()
 					_healthy = true;
 				}
 			}
+
+			GPS_INFO("Ublox Reconfiguring");
 
 			if (_healthy) {
 				_healthy = false;

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -76,6 +76,7 @@
 #endif /* __PX4_LINUX */
 
 #define TIMEOUT_1HZ		1300	//!< Timeout time in mS, 1000 mS (1Hz) + 300 mS delta for error
+#define TIMEOUT_2_5Hz		700	//!< Timeout in mS, 400mS (2.5Hz) + 300 mS delta for error
 #define TIMEOUT_5HZ		500		//!< Timeout time in mS,  200 mS (5Hz) + 300 mS delta for error
 #define RATE_MEASUREMENT_PERIOD 5000000
 
@@ -847,7 +848,9 @@ GPS::run()
 			if (ubx_mode == GPSDriverUBX::UBXMode::RoverWithMovingBase) {
 				/* The MB rover will wait as long as possible to compute a navigation solution,
 				 * possibly lowering the navigation rate all the way to 1 Hz while doing so. */
-				receive_timeout = TIMEOUT_1HZ;
+				//
+				// Sees.ai reduced timeout to 2.5Hz
+				receive_timeout = TIMEOUT_2_5Hz;
 			}
 
 			while ((helper_ret = _helper->receive(receive_timeout)) > 0 && !should_exit()) {

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -76,7 +76,6 @@
 #endif /* __PX4_LINUX */
 
 #define TIMEOUT_1HZ		1300	//!< Timeout time in mS, 1000 mS (1Hz) + 300 mS delta for error
-#define TIMEOUT_2_5Hz		700	//!< Timeout in mS, 400mS (2.5Hz) + 300 mS delta for error
 #define TIMEOUT_5HZ		500		//!< Timeout time in mS,  200 mS (5Hz) + 300 mS delta for error
 #define RATE_MEASUREMENT_PERIOD 5000000
 
@@ -848,7 +847,7 @@ GPS::run()
 			if (ubx_mode == GPSDriverUBX::UBXMode::RoverWithMovingBase) {
 				/* The MB rover will wait as long as possible to compute a navigation solution,
 				 * possibly lowering the navigation rate all the way to 1 Hz while doing so. */
-				receive_timeout = receive_timeout;
+				receive_timeout = TIMEOUT_1HZ;
 			}
 
 			while ((helper_ret = _helper->receive(receive_timeout)) > 0 && !should_exit()) {

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -165,7 +165,7 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("optical_flow", 1000, 1);
 	add_topic_multi("sensor_accel", 1000, 4);
 	add_topic_multi("sensor_baro", 1000, 4);
-	add_topic_multi("sensor_gps", 1000, 2);
+	add_topic_multi("sensor_gps", 0, 2);
 	add_topic_multi("sensor_gyro", 1000, 4);
 	add_topic_multi("sensor_mag", 1000, 4);
 	add_topic_multi("vehicle_imu", 500, 4);

--- a/src/modules/mavlink/streams/RADIO_STATUS.hpp
+++ b/src/modules/mavlink/streams/RADIO_STATUS.hpp
@@ -64,7 +64,7 @@ private:
 
 		while ((_mavlink->get_free_tx_buf() >= get_size()) && _radio_status_sub.update(&radio_status)) {
 			mavlink_radio_status_t msg{};
-			
+
 			msg.rssi = radio_status.rssi;
 			msg.remrssi = radio_status.remote_rssi;
 			msg.txbuf = radio_status.txbuf;

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -117,6 +117,7 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 			if (_gps_state[i].timestamp != 0) {
 				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor [%i] Timeout. Switch to Altitude mode.", i);
 			}
+
 			_gps_state[i].timestamp = 0;
 			_gps_state[i].fix_type = 0;
 			_gps_state[i].satellites_used = 0;

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -115,7 +115,7 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 			   && (_gps_state[i].timestamp > 0)) {
 			// Timed out - kill the stored fix for this receiver and don't track its (stale) gps_dt
 			if (_gps_state[i].timestamp != 0) {
-				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor Timeout. Switch to Altitude mode.");
+				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor [%i] Timeout. Switch to Altitude mode.", i);
 			}
 			_gps_state[i].timestamp = 0;
 			_gps_state[i].fix_type = 0;

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -114,6 +114,9 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 		} else if ((present_dt >= GPS_TIMEOUT_S)
 			   && (_gps_state[i].timestamp > 0)) {
 			// Timed out - kill the stored fix for this receiver and don't track its (stale) gps_dt
+			if (_gps_state[i].timestamp != 0) {
+				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor Timeout. Switch to Altitude mode.");
+			}
 			_gps_state[i].timestamp = 0;
 			_gps_state[i].fix_type = 0;
 			_gps_state[i].satellites_used = 0;

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
@@ -41,6 +41,7 @@
 #include <lib/matrix/matrix/math.hpp>
 #include <px4_platform_common/defines.h>
 #include <uORB/topics/sensor_gps.h>
+#include <lib/systemlib/mavlink_log.h>
 
 #include <float.h>
 #include <lib/ecl/geo/geo.h>
@@ -142,6 +143,8 @@ private:
 	bool _blend_use_spd_acc{false};
 	bool _blend_use_hpos_acc{false};
 	bool _blend_use_vpos_acc{false};
+
+	orb_advert_t _mavlink_log_pub{nullptr};
 
 	float _blending_time_constant{0.f};
 };


### PR DESCRIPTION
Forked from the PX4 GPS drivers repo so that we can edit the ubx.cpp driver to modify UART2 (uart bridge) to set baud rate to 460800 (as per Ublox documentation for dual RTK heading).

Increased GPS logging rate to raw.

Added debug message for if F9P module reconfigures.

Added mavlink warning for if GPS sensor times out.