### PR TITLE
Dp soc estimation port

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -241,6 +241,7 @@ void Battery::estimateStateOfCharge(const float voltage_v, const float current_a
 			_sees_warning_last = hrt_absolute_time();
 		}
 	}
+
 	// -----------------------------
 	// Else do PX4 Default Behaviour
 	// -----------------------------


### PR DESCRIPTION
This modification was originally made to v1.12.1_dev to improve the PX4 State of Charge estimation (see [Notion page](https://www.notion.so/seesai/PX4-Modification-Summaries-a63c130f10a94a04a41fbdd71a2414d4#a8d18e0ec9dc49c297be827ba8839b03)).
Whilst there had been some adjustments to PX4's battery features, the core SoC estimation remained almost entirely unchanged. Subsequently, the modifications have been ported to v1.13.1_dev in this pull request in an identical fashion.

In summary:

When disarmed, the SoC is based entirely on voltage (added an improved lookup table).

When armed, the SoC is adjusted with coulomb counting (initial SoC - mAh discharged).

If the average cell voltage drops below certain thresholds, warnings are triggered.

The previous modifications in v1.12.1_dev had been implemented over a series of 3 pull requests:
https://github.com/SEESAI/Firmware/pull/11
https://github.com/SEESAI/Firmware/pull/14
https://github.com/SEESAI/Firmware/pull/24