### PR TITLE
Dp gps submodule port

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,10 +14,6 @@
 	path = Tools/sitl_gazebo
 	url = https://github.com/PX4/PX4-SITL_gazebo.git
 	branch = master
-[submodule "src/drivers/gps/devices"]
-	path = src/drivers/gps/devices
-	url = https://github.com/PX4/PX4-GPSDrivers.git
-	branch = master
 [submodule "src/modules/micrortps_bridge/micro-CDR"]
 	path = src/modules/micrortps_bridge/micro-CDR
 	url = https://github.com/PX4/Micro-CDR.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -65,5 +65,5 @@
 	url = https://github.com/eProsima/Micro-XRCE-DDS-Client.git
 [submodule "devices"]
 	path = src/drivers/gps/devices
-	url = git@github.com:SEESAI/PX4-GPSDrivers.git
+	url = https://github.com/SEESAI/PX4-GPSDrivers.git
 	branch = 6534b05_dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -63,3 +63,7 @@
 [submodule "src/modules/microdds_client/Micro-XRCE-DDS-Client"]
 	path = src/modules/microdds_client/Micro-XRCE-DDS-Client
 	url = https://github.com/eProsima/Micro-XRCE-DDS-Client.git
+[submodule "devices"]
+	path = src/drivers/gps/devices
+	url = git@github.com:SEESAI/PX4-GPSDrivers.git
+	branch = 6534b05_dev

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -982,6 +982,8 @@ GPS::run()
 				}
 			}
 
+			GPS_INFO("Ublox Reconfiguring");
+
 			if (_healthy) {
 				_healthy = false;
 				_rate = 0.0f;

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -176,7 +176,7 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("optical_flow", 1000, 1);
 	add_optional_topic_multi("sensor_accel", 1000, 4);
 	add_optional_topic_multi("sensor_baro", 1000, 4);
-	add_topic_multi("sensor_gps", 1000, 2);
+	add_topic_multi("sensor_gps", 0, 2);
 	add_topic_multi("sensor_gnss_relative", 1000, 1);
 	add_optional_topic("pps_capture", 1000);
 	add_optional_topic_multi("sensor_gyro", 1000, 4);

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
@@ -119,6 +119,7 @@ void VehicleGPSPosition::Run()
 
 			_sensor_gps_sub[i].copy(&gps_data);
 			_gps_blending.setGpsData(gps_data, i);
+
 			if (_gps_blending.isFallbackAllowed()) {
 				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor Timeout. Switch to Altitude mode.");
 			}

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.cpp
@@ -36,6 +36,7 @@
 #include <px4_platform_common/log.h>
 #include <lib/geo/geo.h>
 #include <lib/mathlib/mathlib.h>
+#include <lib/systemlib/mavlink_log.h>
 
 namespace sensors
 {
@@ -118,6 +119,10 @@ void VehicleGPSPosition::Run()
 
 			_sensor_gps_sub[i].copy(&gps_data);
 			_gps_blending.setGpsData(gps_data, i);
+			if (_gps_blending.isFallbackAllowed()) {
+				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor Timeout. Switch to Altitude mode.");
+			}
+
 
 			if (!_sensor_gps_sub[i].registered()) {
 				_sensor_gps_sub[i].registerCallback();

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
@@ -99,5 +99,7 @@ private:
 		(ParamFloat<px4::params::SENS_GPS_TAU>) _param_sens_gps_tau,
 		(ParamInt<px4::params::SENS_GPS_PRIME>) _param_sens_gps_prime
 	)
+
+	orb_advert_t _mavlink_log_pub{nullptr};
 };
 }; // namespace sensors

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -123,10 +123,6 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 
 		} else if ((present_dt >= GPS_TIMEOUT_S) && (_gps_state[i].timestamp > 0)) {
 			// Timed out - kill the stored fix for this receiver and don't track its (stale) gps_dt
-			if (_gps_state[i].timestamp != 0) {
-				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor [%i] Timeout. Switch to Altitude mode.", i);
-			}
-
 			_gps_state[i].timestamp = 0;
 			_gps_state[i].fix_type = 0;
 			_gps_state[i].satellites_used = 0;

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -123,6 +123,10 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 
 		} else if ((present_dt >= GPS_TIMEOUT_S) && (_gps_state[i].timestamp > 0)) {
 			// Timed out - kill the stored fix for this receiver and don't track its (stale) gps_dt
+			if (_gps_state[i].timestamp != 0) {
+				mavlink_log_critical(&_mavlink_log_pub, "GPS Sensor [%i] Timeout. Switch to Altitude mode.", i);
+			}
+
 			_gps_state[i].timestamp = 0;
 			_gps_state[i].fix_type = 0;
 			_gps_state[i].satellites_used = 0;

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
@@ -41,6 +41,7 @@
 #include <lib/matrix/matrix/math.hpp>
 #include <px4_platform_common/defines.h>
 #include <uORB/topics/sensor_gps.h>
+#include <lib/systemlib/mavlink_log.h>
 
 #include <float.h>
 #include <lib/geo/geo.h>
@@ -144,4 +145,6 @@ private:
 	bool _blend_use_vpos_acc{false};
 
 	float _blending_time_constant{0.f};
+
+	orb_advert_t _mavlink_log_pub{nullptr};
 };

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
@@ -41,7 +41,6 @@
 #include <lib/matrix/matrix/math.hpp>
 #include <px4_platform_common/defines.h>
 #include <uORB/topics/sensor_gps.h>
-#include <lib/systemlib/mavlink_log.h>
 
 #include <float.h>
 #include <lib/geo/geo.h>
@@ -93,6 +92,7 @@ public:
 		}
 	}
 	int getSelectedGps() const { return _selected_gps; }
+	bool isFallbackAllowed() {return _fallback_allowed;}
 
 private:
 	/*
@@ -145,6 +145,4 @@ private:
 	bool _blend_use_vpos_acc{false};
 
 	float _blending_time_constant{0.f};
-
-	orb_advert_t _mavlink_log_pub{nullptr};
 };


### PR DESCRIPTION
This modification was originally made to v1.12.1_dev to improve the PX4 GPS behaviour (see [Notion page](https://www.notion.so/seesai/PX4-Modification-Timeline-6242335b351e4a53b796edcc79666909#6a0b57a5f1e043e88012fe94a940266f)).

Here, the two Ublox f9p GPS modules which we use for Dual RTK communicate through a uart bridge. Vanilla PX4 mistakenly has the baudrate hard-coded to 230400. We modify this to be 460800 as per ublox documentation guidance.

Additionally, we increase the GPS logging rate and add warning messages to notify when a GPS sensor times out or when it switches between selected primary GPS.

The same modifications have been carried over to v1.13.1_dev in this pull request.

The previous modifications in v1.12.1_dev had been implemented in the following pull request:
[Pull Request 25](https://github.com/SEESAI/Firmware/pull/25)