### PR TITLE
Dp magnetometer port

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -107,6 +107,7 @@ set(msg_files
 	logger_status.msg
 	mag_worker_data.msg
 	magnetometer_bias_estimate.msg
+	magnetometer_noise.msg
 	manual_control_setpoint.msg
 	manual_control_switches.msg
 	mavlink_log.msg

--- a/msg/magnetometer_noise.msg
+++ b/msg/magnetometer_noise.msg
@@ -1,0 +1,14 @@
+
+uint64 timestamp            # time since system start (microseconds)
+
+uint64 timestamp_sample     # the timestamp of the raw data (microseconds)
+
+uint32 device_id            # unique device ID for the selected magnetometer
+
+float32[3] magnetometer_raw_rms  # Raw magnetic field RMS amplitude
+
+float32[3] magnetometer_filtered_rms  # Filtered magnetic field RMS amplitude
+
+# Ideally we publish this externally in sensor_mag as this is published in vehicle_magnetometer.cpp (only 80Hz)
+# However, this seems to stick at a low rate, so this will do for now.
+float32[3] magnetometer_raw # Raw magnetometer data

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -159,7 +159,7 @@ void IST8310::RunImpl()
 	case STATE::MEASURE:
 		RegisterWrite(Register::CNTL1, CNTL1_BIT::MODE_SINGLE_MEASUREMENT);
 		_state = STATE::READ;
-		ScheduleDelayed(20_ms); // Wait at least 6ms. (minimum waiting time for 16 times internal average setup)
+		ScheduleDelayed(6_ms); // Wait at least 6ms. (minimum waiting time for 16 times internal average setup)
 		break;
 
 	case STATE::READ: {
@@ -226,7 +226,8 @@ void IST8310::RunImpl()
 
 			// initiate next measurement
 			RegisterWrite(Register::CNTL1, CNTL1_BIT::MODE_SINGLE_MEASUREMENT);
-			ScheduleDelayed(20_ms); // Wait at least 6ms. (minimum waiting time for 16 times internal average setup)
+			// Change poll rate here
+			ScheduleDelayed(6_ms); // Wait at least 6ms. (minimum waiting time for 16 times internal average setup)
 		}
 
 		break;

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -74,6 +74,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("irlock_report");
 	add_topic("landing_target_pose");
 	add_optional_topic("magnetometer_bias_estimate", 200);
+	add_topic("magnetometer_noise");
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
 	add_topic("mission_result");
@@ -111,7 +112,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_land_detected");
 	add_topic("vehicle_local_position", 100);
 	add_topic("vehicle_local_position_setpoint", 100);
-	add_topic("vehicle_magnetometer", 200);
+	add_topic("vehicle_magnetometer");
 	add_topic("vehicle_rates_setpoint", 20);
 	add_topic("vehicle_roi", 1000);
 	add_topic("vehicle_status");

--- a/src/modules/sensors/sensor_params_mag.c
+++ b/src/modules/sensors/sensor_params_mag.c
@@ -117,3 +117,15 @@ PARAM_DEFINE_INT32(SENS_MAG_MODE, 1);
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_MAG_AUTOCAL, 0);
+
+/**
+ * Magnetometer filter sees.ai
+ *
+ * Set cutoff frequency of magnetometer low-pass filter. Set to 0 to disable.
+ * Enable Sees.ai lp filtered magnetometer
+ *
+ * @category system
+ * @group Sensors
+ * @unit Hz
+ */
+PARAM_DEFINE_INT32(SENS_MAG_LP_CUT, 10);

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -162,6 +162,7 @@ bool VehicleMagnetometer::ParametersUpdate(bool force)
 
 				int cutoff_freq_old = _lp_filter1->get_cutoff_freq();
 				int cutoff_freq_new = _param_sens_mag_lp_cut.get();
+
 				if (cutoff_freq_new != cutoff_freq_old) {
 					_lp_filter1[mag].set_cutoff_frequency(cutoff_freq_new);
 					_lp_filter2[mag].set_cutoff_frequency(cutoff_freq_new);
@@ -463,6 +464,7 @@ void VehicleMagnetometer::Run()
 
 					float dt = 0;
 					float sample_freq = 0;
+
 					if (_param_sens_mag_lp_cut.get() > 0) {
 						// Catch backwards timesteps just in case
 						if (report.timestamp_sample > _mag_filtered_timestamp[uorb_index]) {
@@ -472,15 +474,18 @@ void VehicleMagnetometer::Run()
 
 						const float filter_freq = _param_sens_mag_lp_cut.get();
 
-						if (filter_freq > (0.5f * sample_freq) && (hrt_absolute_time() - _sampling_warning_last) > 10'000'000 ) {
-							mavlink_log_warning(&_mavlink_log_pub, "Warning, magnetometer filter freq too high. Sampling Freq = %f, Filter Freq = %f.", double(sample_freq), double(filter_freq));
+						if (filter_freq > (0.5f * sample_freq) && (hrt_absolute_time() - _sampling_warning_last) > 10'000'000) {
+							mavlink_log_warning(&_mavlink_log_pub,
+									    "Warning, magnetometer filter freq too high. Sampling Freq = %f, Filter Freq = %f.", double(sample_freq),
+									    double(filter_freq));
 							_sampling_warning_last = hrt_absolute_time();
 							_sees_filtering[uorb_index] = false;
-						}
-						else {
+
+						} else {
 							_sees_filtering[uorb_index] = true;
 						}
 					}
+
 					if (_sees_filtering[uorb_index]) {
 
 						// Apply filter and save result
@@ -501,6 +506,7 @@ void VehicleMagnetometer::Run()
 						_last_data[uorb_index] = vect;
 
 					}
+
 					updated[uorb_index] = true;
 				}
 			}
@@ -540,10 +546,11 @@ void VehicleMagnetometer::Run()
 			if (updated[instance] && (_data_sum_count[instance] > 0)) {
 
 				hrt_abstime timestamp_sample{};
+
 				if (_sees_filtering[instance]) {
 					timestamp_sample = _mag_filtered_timestamp[instance];
-				}
-				else {
+
+				} else {
 					timestamp_sample = _timestamp_sample_sum[instance] / _data_sum_count[instance];
 				}
 
@@ -577,6 +584,7 @@ void VehicleMagnetometer::Run()
 							mag_noise_filtered_rms.copyTo(mag_noise_out.magnetometer_filtered_rms);
 							mag_raw.copyTo(mag_noise_out.magnetometer_raw);
 							mag_noise_out.timestamp = hrt_absolute_time();
+
 						} else {
 							// PX4 default behaviour - output averaged value
 							magnetometer_data = _data_sum[instance] / _data_sum_count[instance];

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -159,6 +159,15 @@ bool VehicleMagnetometer::ParametersUpdate(bool force)
 				if (calibration_count != _calibration[mag].calibration_count()) {
 					calibration_updated = true;
 				}
+
+				int cutoff_freq_old = _lp_filter1->get_cutoff_freq();
+				int cutoff_freq_new = _param_sens_mag_lp_cut.get();
+				if (cutoff_freq_new != cutoff_freq_old) {
+					_lp_filter1[mag].set_cutoff_frequency(cutoff_freq_new);
+					_lp_filter2[mag].set_cutoff_frequency(cutoff_freq_new);
+					_rms_calculator_raw[mag].set_cutoff_frequency(cutoff_freq_new);
+					_rms_calculator_filtered[mag].set_cutoff_frequency(cutoff_freq_new);
+				}
 			}
 
 			if (calibration_updated) {
@@ -452,8 +461,46 @@ void VehicleMagnetometer::Run()
 					_data_sum[uorb_index] += vect;
 					_data_sum_count[uorb_index]++;
 
-					_last_data[uorb_index] = vect;
+					float dt = 0;
+					float sample_freq = 0;
+					if (_param_sens_mag_lp_cut.get() > 0) {
+						// Catch backwards timesteps just in case
+						if (report.timestamp_sample > _mag_filtered_timestamp[uorb_index]) {
+							dt = (report.timestamp_sample - _mag_filtered_timestamp[uorb_index]) * 1e-6f;
+							sample_freq = 1.f / dt;
+						}
 
+						const float filter_freq = _param_sens_mag_lp_cut.get();
+
+						if (filter_freq > (0.5f * sample_freq) && (hrt_absolute_time() - _sampling_warning_last) > 10'000'000 ) {
+							mavlink_log_warning(&_mavlink_log_pub, "Warning, magnetometer filter freq too high. Sampling Freq = %f, Filter Freq = %f.", double(sample_freq), double(filter_freq));
+							_sampling_warning_last = hrt_absolute_time();
+							_sees_filtering[uorb_index] = false;
+						}
+						else {
+							_sees_filtering[uorb_index] = true;
+						}
+					}
+					if (_sees_filtering[uorb_index]) {
+
+						// Apply filter and save result
+						_mag_filtered[uorb_index] = _lp_filter2[uorb_index].apply(_lp_filter1[uorb_index].apply(vect, dt), dt);
+						_mag_filtered_timestamp[uorb_index] = report.timestamp_sample;
+
+						// RMS the raw and filtered values for logging
+						_rms_calculator_raw[uorb_index].apply(vect, dt);
+						_rms_calculator_filtered[uorb_index].apply(_mag_filtered[uorb_index], dt);
+
+						// Use filtered values for consistency check
+						_last_data[uorb_index](0) = _mag_filtered[uorb_index](0);
+						_last_data[uorb_index](1) = _mag_filtered[uorb_index](1);
+						_last_data[uorb_index](2) = _mag_filtered[uorb_index](2);
+
+					} else {
+						// Else use the unfiltered values for consistency check
+						_last_data[uorb_index] = vect;
+
+					}
 					updated[uorb_index] = true;
 				}
 			}
@@ -492,7 +539,13 @@ void VehicleMagnetometer::Run()
 		for (int instance = 0; instance < MAX_SENSOR_COUNT; instance++) {
 			if (updated[instance] && (_data_sum_count[instance] > 0)) {
 
-				const hrt_abstime timestamp_sample = _timestamp_sample_sum[instance] / _data_sum_count[instance];
+				hrt_abstime timestamp_sample{};
+				if (_sees_filtering[instance]) {
+					timestamp_sample = _mag_filtered_timestamp[instance];
+				}
+				else {
+					timestamp_sample = _timestamp_sample_sum[instance] / _data_sum_count[instance];
+				}
 
 				if (timestamp_sample >= _last_publication_timestamp[instance] + interval_us) {
 
@@ -505,7 +558,29 @@ void VehicleMagnetometer::Run()
 					}
 
 					if (publish) {
-						const Vector3f magnetometer_data = _data_sum[instance] / _data_sum_count[instance];
+
+						Vector3f magnetometer_data{};
+						magnetometer_noise_s mag_noise_out{};
+
+						if (_sees_filtering[instance]) {
+							// Output filtered values to the main message
+							magnetometer_data = _mag_filtered[instance];
+
+							// Copy raw mag, RMS raw mag and RMS filtered mag to mag_noise_out message ready to be published.
+							const Vector3f mag_raw = _data_sum[instance] / _data_sum_count[instance];
+							const Vector3f mag_noise_raw_rms = _rms_calculator_raw[instance].get_last_value();
+							const Vector3f mag_noise_filtered_rms = _rms_calculator_filtered[instance].get_last_value();
+
+							mag_noise_out.timestamp_sample = _mag_filtered_timestamp[instance];
+							mag_noise_out.device_id = _calibration[instance].device_id();
+							mag_noise_raw_rms.copyTo(mag_noise_out.magnetometer_raw_rms);
+							mag_noise_filtered_rms.copyTo(mag_noise_out.magnetometer_filtered_rms);
+							mag_raw.copyTo(mag_noise_out.magnetometer_raw);
+							mag_noise_out.timestamp = hrt_absolute_time();
+						} else {
+							// PX4 default behaviour - output averaged value
+							magnetometer_data = _data_sum[instance] / _data_sum_count[instance];
+						}
 
 						// populate vehicle_magnetometer and publish
 						vehicle_magnetometer_s out{};
@@ -517,10 +592,12 @@ void VehicleMagnetometer::Run()
 
 						if (multi_mode) {
 							_vehicle_magnetometer_pub[instance].publish(out);
+							_magnetometer_noise_pub[instance].publish(mag_noise_out);
 
 						} else {
 							// otherwise only ever publish the first instance
 							_vehicle_magnetometer_pub[0].publish(out);
+							_magnetometer_noise_pub[0].publish(mag_noise_out);
 						}
 					}
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -60,8 +60,11 @@
 #include <uORB/topics/sensors_status.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_magnetometer.h>
+#include <uORB/topics/magnetometer_noise.h>
+#include <lib/mathlib/math/filter/LowPassFilter1p.hpp>
 
 using namespace time_literals;
+using namespace matrix;
 
 namespace sensors
 {
@@ -78,6 +81,58 @@ public:
 	void PrintStatus();
 
 private:
+
+	class RMSNoiseCalculator
+	{
+
+		/**
+		 * Calculates the RMS noise of the signal (vs the specified low-pass of the signal)
+		 */
+
+	public:
+		RMSNoiseCalculator() = default;
+
+		void set_cutoff_frequency(float cutoff_freq, bool reset_states = true)
+		{
+			_lp_filter_in1.set_cutoff_frequency(cutoff_freq, reset_states);
+			_lp_filter_in2.set_cutoff_frequency(cutoff_freq, reset_states);
+			_lp_filter_out1.set_cutoff_frequency(cutoff_freq, reset_states);
+			_lp_filter_out2.set_cutoff_frequency(cutoff_freq, reset_states);
+		}
+
+		Vector3f get_last_value() {return _last_value;}
+
+		Vector3f apply(const Vector3f &input, const float &dt)
+		{
+			// Highpass the input signal to get the noise amplitude
+			const Vector3f filtered_1Hz = _lp_filter_in2.apply(_lp_filter_in1.apply(input, dt), dt);
+			const Vector3f noise = input - filtered_1Hz;
+
+			// Lowpass the square of the noise to get the averaged squared noise
+			const Vector3f noise_sq = Vector3f(noise(0) * noise(0), //
+							   noise(1) * noise(1), //
+							   noise(2) * noise(2));
+			const Vector3f noise_average = _lp_filter_out2.apply((_lp_filter_out1.apply(noise_sq, dt)), dt);
+
+			// The output is the square root of the noise (sanity check for positive)
+			if (noise_average(0) < 0 || noise_average(1) < 0 || noise_average(2) < 0) {
+				_last_value = Vector3f(0.f, 0.f, 0.f);
+			} else {
+				_last_value = Vector3f(sqrt(noise_average(0)), sqrt(noise_average(1)), sqrt(noise_average(2)));
+			}
+
+			// Return the square root of the average squared noise
+			return _last_value;
+		}
+
+	private:
+		Vector3f _last_value {0.0f, 0.0f, 0.0f};
+		math::LowPassFilter1p<matrix::Vector3f> _lp_filter_in1 {};
+		math::LowPassFilter1p<matrix::Vector3f> _lp_filter_in2 {};
+		math::LowPassFilter1p<matrix::Vector3f> _lp_filter_out1 {};
+		math::LowPassFilter1p<matrix::Vector3f> _lp_filter_out2 {};
+	};
+
 	void Run() override;
 
 	void CheckFailover(const hrt_abstime &time_now_us);
@@ -106,6 +161,13 @@ private:
 		{ORB_ID(vehicle_magnetometer)},
 		{ORB_ID(vehicle_magnetometer)},
 		{ORB_ID(vehicle_magnetometer)},
+	};
+
+	uORB::PublicationMulti<magnetometer_noise_s> _magnetometer_noise_pub[MAX_SENSOR_COUNT] {
+		{ORB_ID(magnetometer_noise)},
+		{ORB_ID(magnetometer_noise)},
+		{ORB_ID(magnetometer_noise)},
+		{ORB_ID(magnetometer_noise)},
 	};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
@@ -173,11 +235,21 @@ private:
 
 	bool _armed{false};
 
+	math::LowPassFilter1p<matrix::Vector3f> _lp_filter1[MAX_SENSOR_COUNT] {};
+	math::LowPassFilter1p<matrix::Vector3f> _lp_filter2[MAX_SENSOR_COUNT] {};
+	RMSNoiseCalculator _rms_calculator_raw[MAX_SENSOR_COUNT] {};
+	RMSNoiseCalculator _rms_calculator_filtered[MAX_SENSOR_COUNT] {};
+	hrt_abstime _mag_filtered_timestamp[MAX_SENSOR_COUNT] {};
+	hrt_abstime _sampling_warning_last{};
+	matrix::Vector3f _mag_filtered[MAX_SENSOR_COUNT] {};
+	bool _sees_filtering[MAX_SENSOR_COUNT] {false};
+
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::CAL_MAG_COMP_TYP>) _param_mag_comp_typ,
 		(ParamBool<px4::params::SENS_MAG_MODE>) _param_sens_mag_mode,
 		(ParamFloat<px4::params::SENS_MAG_RATE>) _param_sens_mag_rate,
-		(ParamBool<px4::params::SENS_MAG_AUTOCAL>) _param_sens_mag_autocal
+		(ParamBool<px4::params::SENS_MAG_AUTOCAL>) _param_sens_mag_autocal,
+		(ParamInt<px4::params::SENS_MAG_LP_CUT>) _param_sens_mag_lp_cut
 	)
 };
 }; // namespace sensors

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -117,6 +117,7 @@ private:
 			// The output is the square root of the noise (sanity check for positive)
 			if (noise_average(0) < 0 || noise_average(1) < 0 || noise_average(2) < 0) {
 				_last_value = Vector3f(0.f, 0.f, 0.f);
+
 			} else {
 				_last_value = Vector3f(sqrt(noise_average(0)), sqrt(noise_average(1)), sqrt(noise_average(2)));
 			}


### PR DESCRIPTION
Porting over Magnetometer modifications from v1.12.1_dev.
This was to handle 50Hz noise due to flying near grid powerlines/pylons. 
Here, we included a low-pass filter with a cut-off frequency of 10Hz and hardcoded the magnetometer to sample at 140Hz (previously hardcoded at 50Hz).

In our original modification, we were using a 2nd order low-pass filter. We've instead implemented two 1st order filters in series as this allows us to feed in a dt (which acts as a dynamic sampling frequency) whereas previously the sampling frequency fed into the filter was hard-coded.

We have also parameterised the cut-off frequency so that it can easily be adjusted or disabled without recompiling.

See [Notion Page](https://www.notion.so/seesai/PX4-Modification-Timeline-6242335b351e4a53b796edcc79666909#9ae29aebf7c5456f97010d81ec0e6af7) for more details on v1.12.1_dev implementation.