### PR TITLE
Backported fix for logs appearing 'blank'

### DIFF
--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -146,7 +146,7 @@ MavlinkLogHandler::_log_request_list(const mavlink_message_t *msg)
 	//-- Check for re-requests (data loss) or new request
 	if (_current_status != LogHandlerState::Inactive) {
 		//-- Is this a new request?
-		if ((request.end - request.start) > _log_count) {
+		if (request.start == 0) {
 			_current_status = LogHandlerState::Inactive;
 			_close_and_unlink_files();
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1852,6 +1852,27 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 int
 Mavlink::task_main(int argc, char *argv[])
 {
+	// If stdin, stdout and/or stderr file descriptors (0, 1, 2)
+	// are not open when mavlink module starts (as might be the case for USB auto-start),
+	// use default /dev/null so that these numbers are not used by other other files.
+	if (fcntl(0, F_GETFD) == -1) {
+		int tmp = open("/dev/null", O_RDONLY);
+		dup2(tmp, 0);
+		close(tmp);
+	}
+
+	if (fcntl(1, F_GETFD) == -1) {
+		int tmp = open("/dev/null", O_WRONLY);
+		dup2(tmp, 1);
+		close(tmp);
+	}
+
+	if (fcntl(2, F_GETFD) == -1) {
+		int tmp = open("/dev/null", O_WRONLY);
+		dup2(tmp, 2);
+		close(tmp);
+	}
+
 	int ch;
 	_baudrate = 57600;
 	_datarate = 0;


### PR DESCRIPTION
Previously, logs would first appear blank in the offload menu of QGC until refresh is pressed.
This also caused issues for Aeneas when offloading.
Therefore, a fix which had been implemented in vanilla PX4 and is described in [this pull request](https://github.com/PX4/PX4-Autopilot/pull/21075) has been backported.