### PR TITLE
Precision land hold position on failure

### DIFF
--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -390,7 +390,7 @@ PrecLand::run_state_search()
 	if (hrt_absolute_time() - _state_start_time > _param_pld_srch_tout.get()*SEC2USEC) {
 		PX4_WARN("Search timed out");
 		mavlink_log_info(&_mavlink_log_pub, "Search timed out");
-		switch_to_state_fallback();
+		switch_to_state_hold_fallback();
 	}
 }
 

--- a/src/modules/navigator/precland.h
+++ b/src/modules/navigator/precland.h
@@ -56,7 +56,8 @@ enum class PrecLandState {
 	FinalApproach, // Final landing approach, even without landing target
 	Search, // Search for landing target
 	Fallback, // Fallback landing method
-	Done // Done landing
+	Done, // Done landing
+	HoldFallback, // Hold at Search altitude
 };
 
 enum class PrecLandMode {
@@ -91,6 +92,7 @@ private:
 	void run_state_final_approach();
 	void run_state_search();
 	void run_state_fallback();
+	void run_state_hold_fallback();
 
 	// attempt to switch to a different state. Returns true if state change was successful, false otherwise
 	bool switch_to_state_start();
@@ -99,6 +101,7 @@ private:
 	bool switch_to_state_final_approach();
 	bool switch_to_state_search();
 	bool switch_to_state_fallback();
+	bool switch_to_state_hold_fallback();
 	bool switch_to_state_done();
 
 	void print_state_switch_message(const char *state_name);


### PR DESCRIPTION
A small update to precision land which, after the retries have been exceeded (or if it cannot find a beacon to start with), ascends / descends to the search altitude, and then holds position indefinitely.

This replaces previous behaviour where it would just execute a normal land.