### PR TITLE
Reduced rates/included streams in Custom Mavlink mode for RFD

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1686,18 +1686,24 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 
 	/* fallthrough */
 	case MAVLINK_MODE_CUSTOM:
-		//stream nothing
-		configure_stream_local("ALTITUDE", 1.5f);
-		configure_stream_local("ATTITUDE", 3.0f);
-		configure_stream_local("BATTERY_STATUS", 0.5f);
+		// This is used for the backup link
+		// EU regulations limit duty cycle to 10%
+		// RFD868 is configured to 200kbps, hence 20kbps effective (10%)
+		// Each mavlink message is 280 bytes
+		// To calculate throughput necessary  Total Hz rate x 280byes
+		// Currently 9.3x280 = 26kbps as of 08/03/2023!
+		// Have subsequently reduced rates/included streams.
+		// QGC also needs to send manual control, so need to bare that in mind.
+		configure_stream_local("ALTITUDE", 1.0f);
+		configure_stream_local("ATTITUDE", 2.0f);
+		configure_stream_local("BATTERY_STATUS", 0.1f);
 		configure_stream_local("EXTENDED_SYS_STATE", 0.1f);
 		configure_stream_local("GLOBAL_POSITION_INT", 1.5f);
 		configure_stream_local("GPS_RAW_INT", 0.5f);
 		configure_stream_local("HOME_POSITION", 0.1f);
-		configure_stream_local("RC_CHANNELS", 2.0f);
 		configure_stream_local("SYS_STATUS", 0.1f);
 #if !defined(CONSTRAINED_FLASH)
-		configure_stream_local("LINK_NODE_STATUS", 1.0f);
+		configure_stream_local("LINK_NODE_STATUS", 0.1f);
 #endif // !CONSTRAINED_FLASH
 		break;
 


### PR DESCRIPTION
This update to the Mavlink custom mode is to reduce the mavlink stream throughput for the RFD868 backuplink configuration.
It was noted that we have a limitation of 20kbps using RFD and with each mavlink message being up to 280bytes we were potentially exceeding this.
With this update, the mavlink stream throughput is 15.04kbps.