### PR TITLE
Added landing_target_estimator to start sequence

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -541,6 +541,14 @@ else
 	. ${R}etc/init.d/rc.logging
 
 	#
+	# Start the Landing Target Estimator for precision land
+	#
+	if param compare -s SENS_EN_IRLOCK 1
+	then
+		landing_target_estimator start
+	fi
+
+	#
 	# Set additional parameters and env variables for selected AUTOSTART.
 	#
 	if ! param compare SYS_AUTOSTART 0


### PR DESCRIPTION
Landing_target_estimator module was not starting on fc boot.
Previously, we had hotfixed it by adding a file to etc/extras.txt on the SD card, however this is not a good long-term solution.
Instead, we have added it to rcS.