### PR TITLE
Magnetometer filter warning changed to only alert pilot of primary magnetometer

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         config: [
@@ -18,9 +18,6 @@ jobs:
           px4_sitl
           #tests, # includes px4_sitl
           ]
-        exclude:
-        - config: px4_fmu-v5_default
-        - config: px4_sitl
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -18,6 +18,9 @@ jobs:
           px4_sitl
           #tests, # includes px4_sitl
           ]
+        exclude:
+        - config: px4_fmu-v5_default
+        - config: px4_sitl
     steps:
     - uses: actions/checkout@v1
       with:

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -474,11 +474,13 @@ void VehicleMagnetometer::Run()
 
 						const float filter_freq = _param_sens_mag_lp_cut.get();
 
-						if (filter_freq > (0.5f * sample_freq) && (hrt_absolute_time() - _sampling_warning_last) > 10'000'000) {
-							mavlink_log_warning(&_mavlink_log_pub,
-									    "Warning, magnetometer filter freq too high. Sampling Freq = %f, Filter Freq = %f.", double(sample_freq),
-									    double(filter_freq));
-							_sampling_warning_last = hrt_absolute_time();
+						if (filter_freq > (0.5f * sample_freq) && (hrt_absolute_time() - _sampling_warning_last[uorb_index]) > 10'000'000) {
+							if (uorb_index == _selected_sensor_sub_index){
+								mavlink_log_warning(&_mavlink_log_pub,
+										"Warning, primary magnetometer (%i) filter freq too high. Sampling Freq = %f, Filter Freq = %f.",
+										uorb_index, double(sample_freq), double(filter_freq));
+							}
+							_sampling_warning_last[uorb_index] = hrt_absolute_time();
 							_sees_filtering[uorb_index] = false;
 
 						} else {

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -475,11 +475,12 @@ void VehicleMagnetometer::Run()
 						const float filter_freq = _param_sens_mag_lp_cut.get();
 
 						if (filter_freq > (0.5f * sample_freq) && (hrt_absolute_time() - _sampling_warning_last[uorb_index]) > 10'000'000) {
-							if (uorb_index == _selected_sensor_sub_index){
+							if (uorb_index == _selected_sensor_sub_index) {
 								mavlink_log_warning(&_mavlink_log_pub,
-										"Warning, primary magnetometer (%i) filter freq too high. Sampling Freq = %f, Filter Freq = %f.",
-										uorb_index, double(sample_freq), double(filter_freq));
+										    "Warning, primary magnetometer (%i) filter freq too high. Sampling Freq = %f, Filter Freq = %f.",
+										    uorb_index, double(sample_freq), double(filter_freq));
 							}
+
 							_sampling_warning_last[uorb_index] = hrt_absolute_time();
 							_sees_filtering[uorb_index] = false;
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -241,7 +241,7 @@ private:
 	RMSNoiseCalculator _rms_calculator_raw[MAX_SENSOR_COUNT] {};
 	RMSNoiseCalculator _rms_calculator_filtered[MAX_SENSOR_COUNT] {};
 	hrt_abstime _mag_filtered_timestamp[MAX_SENSOR_COUNT] {};
-	hrt_abstime _sampling_warning_last{};
+	hrt_abstime _sampling_warning_last[MAX_SENSOR_COUNT] {};
 	matrix::Vector3f _mag_filtered[MAX_SENSOR_COUNT] {};
 	bool _sees_filtering[MAX_SENSOR_COUNT] {false};
 


### PR DESCRIPTION
## Problem
In short, each mag has its own filter (implemented by us), and that warning flags when any of the mag filters are disabled due to sampling too slowly. Therefore the CAN mags will continue flagging this every 10s even though we're using the I2C mag which is working properly with its filter.

## Solution
Initially this warning would trigger every 10s (one generic 'warning_last' that covers all mags) if any of the mags were being filtered inappropriately (leading to disabling of its filter). Now, the warning only triggers for the primary magnetometer. The functionality of the filters does not change, only which magnetometer the pilot is alerted to when its filter fails.

### Additional Changes
Updated the macOS environment version to macOS-11 as macOS-10.15 tests would queue but no worker would be assigned.
Suspected due to https://github.com/actions/runner-images/issues/5583