### PR TITLE
Increasing High-Rate topic rates to original 'unlimited' to enable FFT plots

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -59,8 +59,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("camera_trigger");
 	add_topic("cellular_status", 200);
 	add_topic("commander_state");
-	add_topic("cpuload", 50);
-	add_topic("drag_estimator");
+	add_topic("cpuload");
 	add_optional_topic("esc_status", 250);
 	add_topic("failure_detector_status", 100);
 	add_optional_topic("follow_target", 500);
@@ -71,10 +70,10 @@ void LoggedTopics::add_default_topics()
 	add_topic("hover_thrust_estimate", 100);
 	add_topic("input_rc", 500);
 	add_optional_topic("internal_combustion_engine_status", 10);
-	add_topic("irlock_report");
-	add_topic("landing_target_pose");
+	add_optional_topic("irlock_report", 1000);
+	add_optional_topic("landing_target_pose", 1000);
 	add_optional_topic("magnetometer_bias_estimate", 200);
-	add_topic("magnetometer_noise");
+	add_topic("magnetometer_noise", 200);				// Sees.ai - Added topic for monitoring mag disturbance and filter performance (e.g pylons)
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
 	add_topic("mission_result");
@@ -99,7 +98,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("tecs_status", 200);
 	add_topic("trajectory_setpoint", 200);
 	add_topic("transponder_report");
-	add_topic("vehicle_acceleration", 50);
+	add_topic("vehicle_acceleration", 20);
 	add_topic("vehicle_air_data", 200);
 	add_topic("vehicle_angular_velocity", 50);
 	add_topic("vehicle_attitude", 50);
@@ -108,12 +107,12 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_constraints", 1000);
 	add_topic("vehicle_control_mode");
 	add_topic("vehicle_global_position", 200);
-	add_topic("vehicle_gps_position", 500);
+	add_topic("vehicle_gps_position", 20);				// Sees.ai - Increased rate as used in SeesAnalytics plots
 	add_topic("vehicle_land_detected");
 	add_topic("vehicle_local_position", 100);
 	add_topic("vehicle_local_position_setpoint", 100);
-	add_topic("vehicle_magnetometer");
-	add_topic("vehicle_rates_setpoint", 50);
+	add_topic("vehicle_magnetometer");				// Sees.ai - Increased rate to monitor mag disturbance
+	add_topic("vehicle_rates_setpoint", 20);
 	add_topic("vehicle_roi", 1000);
 	add_topic("vehicle_status");
 	add_topic("vehicle_status_flags");
@@ -143,16 +142,16 @@ void LoggedTopics::add_default_topics()
 
 	// always add the first instance
 	add_topic("estimator_baro_bias", 500);
-	add_topic("estimator_event_flags", 50);
+	add_topic("estimator_event_flags", 0);				// Sees.ai - Reduced rate to minimise logging load
 	add_topic("estimator_gps_status", 1000);
 	add_topic("estimator_innovation_test_ratios", 500);
 	add_topic("estimator_innovation_variances", 500);
 	add_topic("estimator_innovations", 500);
 	add_topic("estimator_optical_flow_vel", 200);
-	add_topic("estimator_sensor_bias", 50);
+	add_topic("estimator_sensor_bias", 0);				// Sees.ai - Reduced rate to minimise logging load
 	add_topic("estimator_states", 1000);
 	add_topic("estimator_status", 200);
-	add_topic("estimator_status_flags", 50);
+	add_topic("estimator_status_flags", 0);				// Sees.ai - Reduced rate to minimise logging load
 	add_topic("estimator_visual_odometry_aligned", 200);
 	add_topic("yaw_estimator_status", 1000);
 
@@ -173,15 +172,15 @@ void LoggedTopics::add_default_topics()
 	// log all raw sensors at minimal rate (at least 1 Hz)
 	add_topic_multi("battery_status", 200, 2);
 	add_topic_multi("differential_pressure", 1000, 2);
-	add_topic_multi("distance_sensor", 1000, 2);
+	add_topic_multi("distance_sensor", 0, 2);			// Sees.ai - Increased logging rate as generally helpful
 	add_topic_multi("optical_flow", 1000, 1);
 	add_optional_topic_multi("sensor_accel", 1000, 4);
 	add_optional_topic_multi("sensor_baro", 1000, 4);
-	add_topic_multi("sensor_gps", 0, 2);
+	add_topic_multi("sensor_gps", 0, 2);				// Sees.ai - Increased logging rate for gps as generally helpful
 	add_topic_multi("sensor_gnss_relative", 1000, 1);
 	add_optional_topic("pps_capture", 1000);
 	add_optional_topic_multi("sensor_gyro", 1000, 4);
-	add_topic_multi("sensor_mag", 1000, 4);
+	add_topic_multi("sensor_mag", 1000, 4);				// Sees.ai - Upgraded from "optional" to ensure raw mag is logged
 	add_topic_multi("vehicle_imu", 500, 4);
 	add_topic_multi("vehicle_imu_status", 1000, 4);
 	add_optional_topic_multi("vehicle_magnetometer", 500, 4);
@@ -274,20 +273,20 @@ void LoggedTopics::add_debug_topics()
 void LoggedTopics::add_estimator_replay_topics()
 {
 	// for estimator replay (need to be at full rate)
-	add_topic("ekf2_timestamps", 50);
+	add_topic("ekf2_timestamps");
 
 	// current EKF2 subscriptions
-	add_topic("airspeed", 50);
-	add_topic("optical_flow", 50);
-	add_topic("sensor_combined", 50);
-	add_topic("sensor_selection", 50);
-	add_topic("vehicle_air_data", 50);
-	add_topic("vehicle_gps_position", 50);
-	add_topic("vehicle_land_detected", 50);
-	add_topic("vehicle_magnetometer", 50);
-	add_topic("vehicle_status", 50);
-	add_topic("vehicle_visual_odometry", 50);
-	add_topic_multi("distance_sensor", 50);
+	add_topic("airspeed");
+	add_topic("optical_flow");
+	add_topic("sensor_combined");
+	add_topic("sensor_selection");
+	add_topic("vehicle_air_data");
+	add_topic("vehicle_gps_position");
+	add_topic("vehicle_land_detected");
+	add_topic("vehicle_magnetometer");
+	add_topic("vehicle_status");
+	add_topic("vehicle_visual_odometry");
+	add_topic_multi("distance_sensor");
 }
 
 void LoggedTopics::add_thermal_calibration_topics()

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -73,8 +73,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("irlock_report", 1000);
 	add_optional_topic("landing_target_pose", 1000);
 	add_optional_topic("magnetometer_bias_estimate", 200);
-	add_topic("magnetometer_noise",
-		  200);				// Sees.ai - Added topic for monitoring mag disturbance and filter performance (e.g pylons)
+	add_topic("magnetometer_noise", 200);				// Sees.ai - Added topic for monitoring mag disturbance/filter performance
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
 	add_topic("mission_result");

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -149,6 +149,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("estimator_innovations", 500);
 	add_topic("estimator_optical_flow_vel", 200);
 	add_topic("estimator_sensor_bias", 0);
+	add_topic("estimator_states", 1000);
 	add_topic("estimator_status", 200);
 	add_topic("estimator_status_flags", 0);
 	add_topic("estimator_visual_odometry_aligned", 200);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -246,17 +246,17 @@ void LoggedTopics::add_default_topics()
 void LoggedTopics::add_high_rate_topics()
 {
 	// maximum rate to analyze fast maneuvers (e.g. for racing)
-	add_topic("actuator_controls_0", 50);
-	add_topic("actuator_outputs", 50);
-	add_topic("manual_control_setpoint", 50);
-	add_topic("rate_ctrl_status", 50);
-	add_topic("rate_ctrl_status_detail", 50);
-	add_topic("sensor_combined", 50);
-	add_topic("vehicle_angular_acceleration", 50);
-	add_topic("vehicle_angular_velocity", 50);
-	add_topic("vehicle_attitude", 50);
-	add_topic("vehicle_attitude_setpoint", 50);
-	add_topic("vehicle_rates_setpoint", 50);
+	add_topic("actuator_controls_0", 300);
+	add_topic("actuator_outputs", 300);
+	add_topic("manual_control_setpoint", 300);
+	add_topic("rate_ctrl_status", 20);
+	add_topic("rate_ctrl_status_detail", 300);
+	add_topic("sensor_combined", 300);
+	add_topic("vehicle_angular_acceleration", 300);
+	add_topic("vehicle_angular_velocity", 300);
+	add_topic("vehicle_attitude", 300);
+	add_topic("vehicle_attitude_setpoint", 300);
+	add_topic("vehicle_rates_setpoint", 300);
 }
 
 void LoggedTopics::add_debug_topics()

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -98,9 +98,9 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("tecs_status", 200);
 	add_topic("trajectory_setpoint", 200);
 	add_topic("transponder_report");
-	add_topic("vehicle_acceleration", 20);
+	add_topic("vehicle_acceleration", 50);
 	add_topic("vehicle_air_data", 200);
-	add_topic("vehicle_angular_velocity", 50);
+	add_topic("vehicle_angular_velocity", 20);
 	add_topic("vehicle_attitude", 50);
 	add_topic("vehicle_attitude_setpoint", 50);
 	add_topic("vehicle_command");
@@ -142,16 +142,15 @@ void LoggedTopics::add_default_topics()
 
 	// always add the first instance
 	add_topic("estimator_baro_bias", 500);
-	add_topic("estimator_event_flags", 0);				// Sees.ai - Reduced rate to minimise logging load
+	add_topic("estimator_event_flags", 0);
 	add_topic("estimator_gps_status", 1000);
 	add_topic("estimator_innovation_test_ratios", 500);
 	add_topic("estimator_innovation_variances", 500);
 	add_topic("estimator_innovations", 500);
 	add_topic("estimator_optical_flow_vel", 200);
-	add_topic("estimator_sensor_bias", 0);				// Sees.ai - Reduced rate to minimise logging load
-	add_topic("estimator_states", 1000);
+	add_topic("estimator_sensor_bias", 0);
 	add_topic("estimator_status", 200);
-	add_topic("estimator_status_flags", 0);				// Sees.ai - Reduced rate to minimise logging load
+	add_topic("estimator_status_flags", 0);
 	add_topic("estimator_visual_odometry_aligned", 200);
 	add_topic("yaw_estimator_status", 1000);
 
@@ -249,7 +248,7 @@ void LoggedTopics::add_high_rate_topics()
 	add_topic("actuator_outputs");
 	add_topic("manual_control_setpoint");
 	add_topic("rate_ctrl_status", 20);
-	add_topic("rate_ctrl_status_detail");
+	add_topic("rate_ctrl_status_detail");				// Sees.ai - Added topic for rate loop tuning
 	add_topic("sensor_combined");
 	add_topic("vehicle_angular_acceleration");
 	add_topic("vehicle_angular_velocity");

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -246,17 +246,17 @@ void LoggedTopics::add_default_topics()
 void LoggedTopics::add_high_rate_topics()
 {
 	// maximum rate to analyze fast maneuvers (e.g. for racing)
-	add_topic("actuator_controls_0", 300);
-	add_topic("actuator_outputs", 300);
-	add_topic("manual_control_setpoint", 300);
+	add_topic("actuator_controls_0");
+	add_topic("actuator_outputs");
+	add_topic("manual_control_setpoint");
 	add_topic("rate_ctrl_status", 20);
-	add_topic("rate_ctrl_status_detail", 300);
-	add_topic("sensor_combined", 300);
-	add_topic("vehicle_angular_acceleration", 300);
-	add_topic("vehicle_angular_velocity", 300);
-	add_topic("vehicle_attitude", 300);
-	add_topic("vehicle_attitude_setpoint", 300);
-	add_topic("vehicle_rates_setpoint", 300);
+	add_topic("rate_ctrl_status_detail");
+	add_topic("sensor_combined");
+	add_topic("vehicle_angular_acceleration");
+	add_topic("vehicle_angular_velocity");
+	add_topic("vehicle_attitude");
+	add_topic("vehicle_attitude_setpoint");
+	add_topic("vehicle_rates_setpoint");
 }
 
 void LoggedTopics::add_debug_topics()

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -73,7 +73,8 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("irlock_report", 1000);
 	add_optional_topic("landing_target_pose", 1000);
 	add_optional_topic("magnetometer_bias_estimate", 200);
-	add_topic("magnetometer_noise", 200);				// Sees.ai - Added topic for monitoring mag disturbance and filter performance (e.g pylons)
+	add_topic("magnetometer_noise",
+		  200);				// Sees.ai - Added topic for monitoring mag disturbance and filter performance (e.g pylons)
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
 	add_topic("mission_result");


### PR DESCRIPTION
We had previously reduced several topic rates including 'high-rate' topics to 50Hz from unlimited to minimise logging dropouts.
However this is not sufficient for FFT plots, so we are reverting only the 'high-rate' topics back to unlimited.
