### PR TITLE
Corrected conversion from deci to Amps

### DIFF
--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -155,7 +155,7 @@ void Batmon::RunImpl()
         } else {
                 // Read current in cA.
                 ret |= _interface->read_word(BATT_SMBUS_DECI_CURRENT, result);
-                new_report.current_a = (-1.0f * ((float)(*(int16_t *)&result)) / 100.0f);
+                new_report.current_a = (-1.0f * ((float)(*(int16_t *)&result)) / 10.0f);
         }
         new_report.current_filtered_a = new_report.current_a;
 


### PR DESCRIPTION
### Problem
We'd made a mistake dividing by 100 instead of 10 on the deci-current converison in [this PR](https://github.com/SEESAI/Firmware/pull/56).

### Solution
Correct to divide by 10.