### PR TITLE
Dp ob manual control update

### DIFF
--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -54,7 +54,8 @@ float32 aux6
 bool sticks_moving
 
 bool toggle_control_source		 # request to toggle between Mavlink and RC control source
-bool SEES_SOURCE_RC = 0
-bool SEES_SOURCE_MAV = 1
+int8 SEES_SOURCE_NONE = -1
+int8 SEES_SOURCE_RC = 0
+int8 SEES_SOURCE_MAV = 1
 
 # TOPICS manual_control_setpoint manual_control_input

--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -54,8 +54,8 @@ float32 aux6
 bool sticks_moving
 
 bool toggle_control_source		 # request to toggle between Mavlink and RC control source
-int8 SEES_SOURCE_NONE = -1
-int8 SEES_SOURCE_RC = 0
-int8 SEES_SOURCE_MAV = 1
+int8 SEES_SOURCE_NONE = 0
+int8 SEES_SOURCE_RC = 1
+int8 SEES_SOURCE_MAV = 2
 
 # TOPICS manual_control_setpoint manual_control_input

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -207,15 +207,15 @@ void sPort_send_CUR(int uart)
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
-	// If the input type is RC then set it to 0
+	// If the input type is RC then set it to 1
 	else if (control_source == manual_control_setpoint_s::SOURCE_RC) {
-		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 0
+		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 1
 	}
 
-	// Else if the input type is Mavlink then set it to 1
+	// Else if the input type is Mavlink then set it to 2
 	else if (control_source >= manual_control_setpoint_s::SOURCE_MAVLINK_0
 		 && control_source <= manual_control_setpoint_s::SOURCE_MAVLINK_5) {
-		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 1
+		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 2
 	}
 
 	sPort_send_data(uart, SMARTPORT_ID_CURR, control_source);
@@ -424,15 +424,15 @@ void sPort_send_DIY_rcmav(int uart)
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
-	// If the input type is RC then set it to 0
+	// If the input type is RC then set it to 1
 	else if (control_source == manual_control_setpoint_s::SOURCE_RC) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 0
+		control_source = manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 1
 	}
 
-	// Else if the input type is Mavlink then set it to 1
+	// Else if the input type is Mavlink then set it to 2
 	else if (control_source >= manual_control_setpoint_s::SOURCE_MAVLINK_0
 		 && control_source <= manual_control_setpoint_s::SOURCE_MAVLINK_5) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 1
+		control_source = manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 2
 	}
 
 	PX4_INFO("value = %i", control_source);

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -200,7 +200,7 @@ void sPort_send_BATV(int uart)
 void sPort_send_CUR(int uart)
 {
 	/* Hijacked to send Data Source type (Mav/RC Control)(David @sees.ai) */
-	int32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	int control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
 	if (!control_source_valid) {
@@ -417,7 +417,7 @@ void sPort_send_DIY_gps_mb(int uart)
 void sPort_send_DIY_rcmav(int uart)
 {
 	// OBManual Control Mode
-	int32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	int control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
 	if (!control_source_valid) {

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -202,8 +202,9 @@ void sPort_send_CUR(int uart)
 	/* Hijacked to send Data Source type (Mav/RC Control)(David @sees.ai) */
 	int16_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
+	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
-	if (hrt_absolute_time() - control_source_timestamp > 500'000) {
+	if ((!control_source_valid) && (hrt_absolute_time() - control_source_timestamp > 500'000)) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
@@ -419,8 +420,9 @@ void sPort_send_DIY_rcmav(int uart)
 	// OBManual Control Mode
 	int16_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
+	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
-	if (hrt_absolute_time() - control_source_timestamp > 500'000) {
+	if ((!control_source_valid) && (hrt_absolute_time() - control_source_timestamp > 500'000)) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -201,9 +201,14 @@ void sPort_send_CUR(int uart)
 {
 	/* Hijacked to send Data Source type (Mav/RC Control)(David @sees.ai) */
 	uint32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 
 	// If the input type is RC then set it to 0
-	if (control_source == manual_control_setpoint_s::SOURCE_RC) {
+	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
+		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
+	}
+
+	else if (control_source == manual_control_setpoint_s::SOURCE_RC) {
 		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 0
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -203,7 +203,7 @@ void sPort_send_CUR(int uart)
 	int16_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 
-	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
+	if (hrt_absolute_time() - control_source_timestamp > 500'000) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
@@ -420,7 +420,7 @@ void sPort_send_DIY_rcmav(int uart)
 	int16_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 
-	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
+	if (hrt_absolute_time() - control_source_timestamp > 500'000) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -200,7 +200,7 @@ void sPort_send_BATV(int uart)
 void sPort_send_CUR(int uart)
 {
 	/* Hijacked to send Data Source type (Mav/RC Control)(David @sees.ai) */
-	uint32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	int32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
 	if (!control_source_valid) {
@@ -417,7 +417,7 @@ void sPort_send_DIY_gps_mb(int uart)
 void sPort_send_DIY_rcmav(int uart)
 {
 	// OBManual Control Mode
-	uint32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	int32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
 	if (!control_source_valid) {
@@ -435,6 +435,7 @@ void sPort_send_DIY_rcmav(int uart)
 		control_source = manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 1
 	}
 
+	PX4_INFO("value = %i", control_source);
 	sPort_send_data(uart, SMARTPORT_ID_RCMAV, control_source);
 }
 

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -203,11 +203,11 @@ void sPort_send_CUR(int uart)
 	uint32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
 	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 
-	// If the input type is RC then set it to 0
 	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
+	// If the input type is RC then set it to 0
 	else if (control_source == manual_control_setpoint_s::SOURCE_RC) {
 		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 0
 	}
@@ -418,9 +418,14 @@ void sPort_send_DIY_rcmav(int uart)
 {
 	// OBManual Control Mode
 	uint32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
+
+	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
+		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
+	}
 
 	// If the input type is RC then set it to 0
-	if (control_source == manual_control_setpoint_s::SOURCE_RC) {
+	else if (control_source == manual_control_setpoint_s::SOURCE_RC) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 0
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -201,9 +201,9 @@ void sPort_send_CUR(int uart)
 {
 	/* Hijacked to send Data Source type (Mav/RC Control)(David @sees.ai) */
 	uint32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
-	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
+	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
-	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
+	if (!control_source_valid) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
@@ -418,9 +418,9 @@ void sPort_send_DIY_rcmav(int uart)
 {
 	// OBManual Control Mode
 	uint32_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
-	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
+	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
-	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
+	if (!control_source_valid) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -204,8 +204,9 @@ void sPort_send_CUR(int uart)
 	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
+	// If the input has been invalid for >0.5s, then set it to 0
 	if ((!control_source_valid) && (hrt_absolute_time() - control_source_timestamp > 500'000)) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
+		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE; // This equates to 0
 	}
 
 	// If the input type is RC then set it to 1
@@ -422,8 +423,9 @@ void sPort_send_DIY_rcmav(int uart)
 	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
 
+	// If the input has been invalid for >0.5s, then set it to 0
 	if ((!control_source_valid) && (hrt_absolute_time() - control_source_timestamp > 500'000)) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
+		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE; // This equates to 0
 	}
 
 	// If the input type is RC then set it to 1

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -200,10 +200,10 @@ void sPort_send_BATV(int uart)
 void sPort_send_CUR(int uart)
 {
 	/* Hijacked to send Data Source type (Mav/RC Control)(David @sees.ai) */
-	int control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
-	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
+	int16_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 
-	if (!control_source_valid) {
+	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
@@ -417,10 +417,10 @@ void sPort_send_DIY_gps_mb(int uart)
 void sPort_send_DIY_rcmav(int uart)
 {
 	// OBManual Control Mode
-	int control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
-	bool control_source_valid = s_port_subscription_data->manual_control_setpoint_sub.get().valid;
+	int16_t control_source = s_port_subscription_data->manual_control_setpoint_sub.get().data_source;
+	hrt_abstime control_source_timestamp = s_port_subscription_data->manual_control_setpoint_sub.get().timestamp;
 
-	if (!control_source_valid) {
+	if (hrt_absolute_time() - control_source_timestamp > 1'000'000) {
 		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE;
 	}
 
@@ -435,7 +435,6 @@ void sPort_send_DIY_rcmav(int uart)
 		control_source = manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 2
 	}
 
-	PX4_INFO("value = %i", control_source);
 	sPort_send_data(uart, SMARTPORT_ID_RCMAV, control_source);
 }
 

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -158,6 +158,9 @@ void ManualControl::Run()
 				if (_previous_switches_initialized) {
 					if (switches.mode_slot != _previous_switches.mode_slot) {
 						evaluateModeSlot(switches.mode_slot);
+						// ---Sees.ai--- If the RC Flight Mode switch changes, revert to RC control.
+						// i.e if safety pilot switches to Position Control, then give them control.
+						_selector.setControlSourceRC();
 					}
 
 					if (_param_com_arm_swisbtn.get()) {

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -48,8 +48,11 @@ public:
 
 	// ---Sees.ai--- Added this member function to facilitate toggling between control source.
 	//void toggleControlSource() {_sees_desired_control = !_sees_desired_control; };
-	void toggleControlSource() {_sees_desired_control = _sees_desired_control == manual_control_setpoint_s::SEES_SOURCE_MAV ?
-					manual_control_setpoint_s::SEES_SOURCE_RC : manual_control_setpoint_s::SEES_SOURCE_MAV;}
+	void toggleControlSource()
+	{
+		_sees_desired_control = _sees_desired_control == manual_control_setpoint_s::SEES_SOURCE_MAV ?
+					manual_control_setpoint_s::SEES_SOURCE_RC : manual_control_setpoint_s::SEES_SOURCE_MAV;
+	}
 	void setControlSourceRC() {_sees_desired_control = manual_control_setpoint_s::SEES_SOURCE_RC;} ;
 	bool getSeesDesiredControl() {return _sees_desired_control;};
 

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -47,7 +47,8 @@ public:
 	int instance() const { return _instance; };
 
 	// ---Sees.ai--- Added this member function to facilitate toggling between control source.
-	void toggleControlSource() {_sees_desired_control = !_sees_desired_control;};
+	void toggleControlSource() {_sees_desired_control = !_sees_desired_control; };
+	void setControlSourceRC() {_sees_desired_control = manual_control_setpoint_s::SEES_SOURCE_RC;} ;
 	bool getSeesDesiredControl() {return _sees_desired_control;};
 
 private:

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -47,7 +47,9 @@ public:
 	int instance() const { return _instance; };
 
 	// ---Sees.ai--- Added this member function to facilitate toggling between control source.
-	void toggleControlSource() {_sees_desired_control = !_sees_desired_control; };
+	//void toggleControlSource() {_sees_desired_control = !_sees_desired_control; };
+	void toggleControlSource() {_sees_desired_control = _sees_desired_control == manual_control_setpoint_s::SEES_SOURCE_MAV ?
+					manual_control_setpoint_s::SEES_SOURCE_RC : manual_control_setpoint_s::SEES_SOURCE_MAV;}
 	void setControlSourceRC() {_sees_desired_control = manual_control_setpoint_s::SEES_SOURCE_RC;} ;
 	bool getSeesDesiredControl() {return _sees_desired_control;};
 
@@ -59,5 +61,5 @@ private:
 	int32_t _rc_in_mode{0};
 	int _instance{-1};
 	uint8_t _first_valid_source{manual_control_setpoint_s::SOURCE_UNKNOWN};
-	bool _sees_desired_control{manual_control_setpoint_s::SEES_SOURCE_MAV};
+	int _sees_desired_control{manual_control_setpoint_s::SEES_SOURCE_MAV};
 };


### PR DESCRIPTION
### Problem
The RC Controller telemetry would not update the current Control Source (visual bug only) if only one source is present and it is not the desired source (i.e if desired is MavJoystick but only RC is present).
_Note: the actual functional behaviour is correct, only the feedback to the pilot was showing incorrectly._

This is because if the current Source became invalid, the Control Selector would simply mark it as invalid and it would timeout, but as it wouldn't technically switch to a new Source, this property would stay as whatever the last valid source was.

### Solution
Redefined the possible Control Source states from boolean:
- 0 = RC
- 1 = Mav

to int:
- 0 = No Source
- 1 = RC
- 2 = Mav

If the current source is marked as invalid, then switch the output to RC Controller to reflect this.