### PR TITLE
Yaw on Takeoff Fix

### DIFF
--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -73,6 +73,7 @@ jobs:
         - config: holybro_kakutef7
         - config: px4_fmu-v5
         - config: omnibus_f4sd
+        - config: px4_fmu-v6x
     steps:
     - uses: actions/checkout@v1
       with:

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -982,7 +982,20 @@ void Navigator::publish_position_setpoint_triplet()
 
 float Navigator::get_default_acceptance_radius()
 {
-	return _param_nav_acc_rad.get();
+	// ---Sees.ai---
+	// Sometimes this parameter does not initialise properly, resulting in a negligible value to be returned.
+	// This will cause the drone to yaw uncontrollably on auto-takeoff.
+	// Instead, check that this param is reasonable, and if it isn't then set it to 1.
+	float acceptance_radius = _param_nav_acc_rad.get();
+
+	if (acceptance_radius < 0.1f || acceptance_radius > 25.f) {
+		PX4_INFO("Acceptance radius corrected from %f to 1.0", double(acceptance_radius));
+		float param_set_val = 1.0;
+		param_set(param_find("NAV_ACC_RAD"), &param_set_val);
+		acceptance_radius = 1.0;
+	}
+
+	return acceptance_radius;
 }
 
 float Navigator::get_default_altitude_acceptance_radius()


### PR DESCRIPTION
### Problem
Sometimes, the NAV_ACC_RADIUS parameter will not initialise properly, resulting in a random value (normally negligible or close to max) to be returned.
This causes the drone to yaw uncontrollably on auto-takeoff. See [this notion page](https://www.notion.so/seesai/Bug-Yaw-error-in-take-off-0d17fd21191045d0b42aa63df8914ffd?pvs=4#6138b8141c4b41dc9cde561f191f4e80) for further details.

### Solution
When looking up the NAV_ACC_RAD parameter value, if it's an unreasonable value then set it to 1.0.