### PR TITLE
Dp manualcontrol refactor

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -142,6 +142,7 @@ set(msg_files
 	rtl_time_estimate.msg
 	safety.msg
 	satellite_info.msg
+	sees_manual_control_data.msg
 	sensor_accel.msg
 	sensor_accel_fifo.msg
 	sensor_baro.msg

--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -54,8 +54,8 @@ float32 aux6
 bool sticks_moving
 
 bool toggle_control_source		 # request to toggle between Mavlink and RC control source
-int8 SEES_SOURCE_NONE = 0
-int8 SEES_SOURCE_RC = 1
-int8 SEES_SOURCE_MAV = 2
+bool is_updating			 # simple check that timestamp is valid and not stale
+uint8 sees_desired_control_source	 # desired type of manual control source, RC (1) or Mav (2)
+uint64 mavlink_count			 # number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.
 
 # TOPICS manual_control_setpoint manual_control_input

--- a/msg/sees_manual_control_data.msg
+++ b/msg/sees_manual_control_data.msg
@@ -1,0 +1,7 @@
+uint64 timestamp                        # time since system start (microseconds)
+
+uint8 sees_desired_control_source	# desired type of manual control source, RC (1) or Mav (2)
+uint64 valid_mavlink_setpoint_count		# number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.
+uint64 valid_rc_setpoint_count			# number of RC connections providing setpoints. Should be < 2.
+
+# TOPICS sees_manual_control_data

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -206,18 +206,18 @@ void sPort_send_CUR(int uart)
 
 	// If the input has been invalid for >0.5s, then set it to 0
 	if ((!control_source_valid) && (hrt_absolute_time() - control_source_timestamp > 500'000)) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE; // This equates to 0
+		control_source = manual_control_setpoint_s::SOURCE_UNKNOWN; // This equates to 0
 	}
 
 	// If the input type is RC then set it to 1
 	else if (control_source == manual_control_setpoint_s::SOURCE_RC) {
-		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 1
+		control_source = 10 * manual_control_setpoint_s::SOURCE_RC; // This equates to 1
 	}
 
 	// Else if the input type is Mavlink then set it to 2
 	else if (control_source >= manual_control_setpoint_s::SOURCE_MAVLINK_0
 		 && control_source <= manual_control_setpoint_s::SOURCE_MAVLINK_5) {
-		control_source = 10 * manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 2
+		control_source = 10 * manual_control_setpoint_s::SOURCE_MAVLINK_0; // This equates to 2
 	}
 
 	sPort_send_data(uart, SMARTPORT_ID_CURR, control_source);
@@ -425,18 +425,19 @@ void sPort_send_DIY_rcmav(int uart)
 
 	// If the input has been invalid for >0.5s, then set it to 0
 	if ((!control_source_valid) && (hrt_absolute_time() - control_source_timestamp > 500'000)) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_NONE; // This equates to 0
+		control_source =
+			manual_control_setpoint_s::SOURCE_UNKNOWN; // This equates to 0 and in this case indicates no valid setpoint.
 	}
 
 	// If the input type is RC then set it to 1
 	else if (control_source == manual_control_setpoint_s::SOURCE_RC) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_RC; // This equates to 1
+		control_source = manual_control_setpoint_s::SOURCE_RC; // This equates to 1
 	}
 
 	// Else if the input type is Mavlink then set it to 2
 	else if (control_source >= manual_control_setpoint_s::SOURCE_MAVLINK_0
 		 && control_source <= manual_control_setpoint_s::SOURCE_MAVLINK_5) {
-		control_source = manual_control_setpoint_s::SEES_SOURCE_MAV; // This equates to 2
+		control_source = manual_control_setpoint_s::SOURCE_MAVLINK_0; // This equates to 2
 	}
 
 	sPort_send_data(uart, SMARTPORT_ID_RCMAV, control_source);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -88,7 +88,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("radio_status");
 	add_topic("rtl_time_estimate", 1000);
 	add_topic("safety");
-	add_topic("sees_manual_control_data");				// Sees.ai - Added topic for monitoring Manual Control Setpoint meta data
+	add_topic("sees_manual_control_data", 100);				// Sees.ai - Added topic for monitoring Manual Control Setpoint meta data
 	add_topic("sensor_combined");
 	add_optional_topic("sensor_correction");
 	add_optional_topic("sensor_gyro_fft", 50);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -88,6 +88,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("radio_status");
 	add_topic("rtl_time_estimate", 1000);
 	add_topic("safety");
+	add_topic("sees_manual_control_data");				// Sees.ai - Added topic for monitoring Manual Control Setpoint meta data
 	add_topic("sensor_combined");
 	add_optional_topic("sensor_correction");
 	add_optional_topic("sensor_gyro_fft", 50);

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -121,16 +121,27 @@ void ManualControl::Run()
 			if (_selector.isInputUpdating(manual_control_input, now)
 			    && manual_control_input.data_source >= manual_control_setpoint_s::SOURCE_MAVLINK_0
 			    && manual_control_input.data_source <= manual_control_setpoint_s::SOURCE_MAVLINK_5) {
-				valid_mavlink_setpoint_count += 1;
+				// valid_mavlink_setpoint_count += 1;
+				_mav_control_sources_valid[i] = true;
 
 			} else if (_selector.isInputUpdating(manual_control_input, now)
 				   && manual_control_input.data_source >= manual_control_setpoint_s::SOURCE_RC) {
-				valid_rc_setpoint_count += 1;
+				// valid_rc_setpoint_count += 1;
+				_rc_control_sources_valid[i] = true;
+
+			} else {
+				_mav_control_sources_valid[i] = false;
+				_rc_control_sources_valid[i] = false;
 			}
 
 			// mavlink_count += _selector.isInputUpdatingAndMavlink(manual_control_input, now);
 			_selector.updateWithNewInputSample(now, manual_control_input, i);
 		}
+	}
+
+	for (int i = 0; i < MAX_MANUAL_INPUT_COUNT; i++) {
+		valid_mavlink_setpoint_count += _mav_control_sources_valid[i];
+		valid_rc_setpoint_count += _rc_control_sources_valid[i];
 	}
 
 	if (control_source_toggled) {

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -248,9 +248,13 @@ void ManualControl::rc_switches_execute(bool switches_updated, const manual_cont
 			if (_previous_switches_initialized) {
 				if (switches.mode_slot != _previous_switches.mode_slot) {
 					evaluateModeSlot(switches.mode_slot);
+
 					// ---Sees.ai--- If the RC Flight Mode switch changes, revert to RC control.
 					// i.e if safety pilot switches to Position Control, then give them control.
-					_selector.setControlSourceRC();
+					if (_selector.getSeesDesiredControl() != manual_control_setpoint_s::SOURCE_RC) {
+						_selector.setControlSourceRC();
+						mavlink_log_info(&_mavlink_log_pub, "Flight Mode changed by RC. Switching to RC Control.");
+					}
 				}
 
 				if (_param_com_arm_swisbtn.get()) {

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -150,6 +150,8 @@ private:
 
 	sees_manual_control_data_s _sees_manual_control_data{};
 	bool _mav_control_source_button_prev_state[MAX_MANUAL_INPUT_COUNT] {false};
+	bool _mav_control_sources_valid[MAX_MANUAL_INPUT_COUNT] {false};
+	bool _rc_control_sources_valid[MAX_MANUAL_INPUT_COUNT] {false};
 	bool _control_source_toggled_rc{false};
 	int _transition_switch_prev_state{};
 	orb_advert_t _mavlink_log_pub{nullptr};

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -149,9 +149,10 @@ private:
 	bool _video_recording {false}; // TODO: hopefully there is a command soon to toggle without keeping state
 
 	sees_manual_control_data_s _sees_manual_control_data{};
+	manual_control_setpoint_s _sees_manual_control_inputs[MAX_MANUAL_INPUT_COUNT] {};
 	bool _mav_control_source_button_prev_state[MAX_MANUAL_INPUT_COUNT] {false};
-	bool _mav_control_sources_valid[MAX_MANUAL_INPUT_COUNT] {false};
-	bool _rc_control_sources_valid[MAX_MANUAL_INPUT_COUNT] {false};
+	// bool _mav_control_sources_valid[MAX_MANUAL_INPUT_COUNT] {false};
+	// bool _rc_control_sources_valid[MAX_MANUAL_INPUT_COUNT] {false};
 	bool _control_source_toggled_rc{false};
 	int _transition_switch_prev_state{};
 	orb_advert_t _mavlink_log_pub{nullptr};

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -46,6 +46,7 @@
 #include <uORB/topics/manual_control_switches.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sees_manual_control_data.h>
 #include <uORB/Publication.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/SubscriptionCallback.hpp>
@@ -97,6 +98,7 @@ private:
 	void send_video_command();
 
 	uORB::Publication<manual_control_setpoint_s> _manual_control_setpoint_pub{ORB_ID(manual_control_setpoint)};
+	uORB::Publication<sees_manual_control_data_s> _sees_manual_control_data_pub{ORB_ID(sees_manual_control_data)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	int _previous_manual_control_input_instance{-1};
@@ -146,6 +148,7 @@ private:
 	unsigned _image_sequence {0};
 	bool _video_recording {false}; // TODO: hopefully there is a command soon to toggle without keeping state
 
+	sees_manual_control_data_s _sees_manual_control_data{};
 	bool _mav_control_source_button_prev_state[MAX_MANUAL_INPUT_COUNT] {false};
 	bool _control_source_toggled_rc{false};
 	int _transition_switch_prev_state{};

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -85,6 +85,7 @@ private:
 	void evaluateModeSlot(uint8_t mode_slot);
 	void sendActionRequest(int8_t action, int8_t source, int8_t mode = 0);
 	void publishLandingGear(int8_t action);
+	void rc_switches_execute(bool switches_updated, const manual_control_switches_s &switches, hrt_abstime now);
 
 	uORB::Publication<action_request_s> _action_request_pub{ORB_ID(action_request)};
 	uORB::Publication<landing_gear_s> _landing_gear_pub{ORB_ID(landing_gear)};

--- a/src/modules/manual_control/ManualControlSelector.cpp
+++ b/src/modules/manual_control/ManualControlSelector.cpp
@@ -65,8 +65,7 @@ void ManualControlSelector::updateWithNewInputSample(uint64_t now, const manual_
 bool ManualControlSelector::isInputValid(const manual_control_setpoint_s &input, uint64_t now) const
 {
 	// Check for timeout
-	const bool sample_from_the_past = now >= input.timestamp_sample;
-	const bool sample_newer_than_timeout = now - input.timestamp_sample < _timeout;
+	const bool is_updating = isInputUpdating(input, now);
 
 	// Check if source matches the configuration
 	const bool source_rc_matched = (_rc_in_mode == 0) && (input.data_source == manual_control_setpoint_s::SOURCE_RC);
@@ -83,16 +82,27 @@ bool ManualControlSelector::isInputValid(const manual_control_setpoint_s &input,
 					   || _first_valid_source == manual_control_setpoint_s::SOURCE_UNKNOWN);
 	const bool sees_desired_matched = (_rc_in_mode == 5) &&
 					  ((input.data_source == manual_control_setpoint_s::SOURCE_RC
-					    && _sees_desired_control == manual_control_setpoint_s::SEES_SOURCE_RC)
+					    && _sees_desired_control == manual_control_setpoint_s::SOURCE_RC)
 					   || (input.data_source >= manual_control_setpoint_s::SOURCE_MAVLINK_0
 					       && input.data_source <= manual_control_setpoint_s::SOURCE_MAVLINK_5
-					       && _sees_desired_control == manual_control_setpoint_s::SEES_SOURCE_MAV));
+					       && _sees_desired_control == manual_control_setpoint_s::SOURCE_MAVLINK_0));
 
-	return sample_from_the_past && sample_newer_than_timeout
+	return is_updating
 	       && (source_rc_matched || source_mavlink_matched || source_any_matched || source_first_matched || sees_desired_matched);
 }
 
 manual_control_setpoint_s &ManualControlSelector::setpoint()
 {
 	return _setpoint;
+}
+
+bool ManualControlSelector::isInputUpdating(const manual_control_setpoint_s &input, uint64_t now) const
+{
+	// Check for timeout
+	const bool sample_from_the_past = now >= input.timestamp_sample;
+	const bool sample_newer_than_timeout = now - input.timestamp_sample < _timeout;
+	// bool is_updating = false;
+
+
+	return sample_from_the_past && sample_newer_than_timeout;
 }

--- a/src/modules/manual_control/ManualControlSelector.cpp
+++ b/src/modules/manual_control/ManualControlSelector.cpp
@@ -101,8 +101,6 @@ bool ManualControlSelector::isInputUpdating(const manual_control_setpoint_s &inp
 	// Check for timeout
 	const bool sample_from_the_past = now >= input.timestamp_sample;
 	const bool sample_newer_than_timeout = now - input.timestamp_sample < _timeout;
-	// bool is_updating = false;
-
 
 	return sample_from_the_past && sample_newer_than_timeout;
 }

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -43,17 +43,19 @@ public:
 	void setTimeout(uint64_t timeout) { _timeout = timeout; }
 	void updateValidityOfChosenInput(uint64_t now);
 	void updateWithNewInputSample(uint64_t now, const manual_control_setpoint_s &input, int instance);
+	// bool isInputUpdatingAndMavlink(const manual_control_setpoint_s &input, uint64_t now) const;
+	bool isInputUpdating(const manual_control_setpoint_s &input, uint64_t now) const;
 	manual_control_setpoint_s &setpoint();
 	int instance() const { return _instance; };
 
 	// ---Sees.ai--- Added this member function to facilitate toggling between control source.
-	//void toggleControlSource() {_sees_desired_control = !_sees_desired_control; };
+	// void toggleControlSource() {_sees_desired_control = !_sees_desired_control; };
 	void toggleControlSource()
 	{
-		_sees_desired_control = _sees_desired_control == manual_control_setpoint_s::SEES_SOURCE_MAV ?
-					manual_control_setpoint_s::SEES_SOURCE_RC : manual_control_setpoint_s::SEES_SOURCE_MAV;
+		_sees_desired_control = _sees_desired_control == manual_control_setpoint_s::SOURCE_MAVLINK_0 ?
+					manual_control_setpoint_s::SOURCE_RC : manual_control_setpoint_s::SOURCE_MAVLINK_0;
 	}
-	void setControlSourceRC() {_sees_desired_control = manual_control_setpoint_s::SEES_SOURCE_RC;} ;
+	void setControlSourceRC() {_sees_desired_control = manual_control_setpoint_s::SOURCE_RC;} ;
 	bool getSeesDesiredControl() {return _sees_desired_control;};
 
 private:
@@ -64,5 +66,5 @@ private:
 	int32_t _rc_in_mode{0};
 	int _instance{-1};
 	uint8_t _first_valid_source{manual_control_setpoint_s::SOURCE_UNKNOWN};
-	int _sees_desired_control{manual_control_setpoint_s::SEES_SOURCE_MAV};
+	int _sees_desired_control{manual_control_setpoint_s::SOURCE_MAVLINK_0};
 };

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -43,20 +43,18 @@ public:
 	void setTimeout(uint64_t timeout) { _timeout = timeout; }
 	void updateValidityOfChosenInput(uint64_t now);
 	void updateWithNewInputSample(uint64_t now, const manual_control_setpoint_s &input, int instance);
-	// bool isInputUpdatingAndMavlink(const manual_control_setpoint_s &input, uint64_t now) const;
 	bool isInputUpdating(const manual_control_setpoint_s &input, uint64_t now) const;
 	manual_control_setpoint_s &setpoint();
 	int instance() const { return _instance; };
 
 	// ---Sees.ai--- Added this member function to facilitate toggling between control source.
-	// void toggleControlSource() {_sees_desired_control = !_sees_desired_control; };
 	void toggleControlSource()
 	{
 		_sees_desired_control = _sees_desired_control == manual_control_setpoint_s::SOURCE_MAVLINK_0 ?
 					manual_control_setpoint_s::SOURCE_RC : manual_control_setpoint_s::SOURCE_MAVLINK_0;
 	}
 	void setControlSourceRC() {_sees_desired_control = manual_control_setpoint_s::SOURCE_RC;} ;
-	bool getSeesDesiredControl() {return _sees_desired_control;};
+	int getSeesDesiredControl() {return _sees_desired_control;};
 
 private:
 	bool isInputValid(const manual_control_setpoint_s &input, uint64_t now) const;

--- a/src/modules/mavlink/streams/SYS_STATUS.hpp
+++ b/src/modules/mavlink/streams/SYS_STATUS.hpp
@@ -39,6 +39,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/rc_channels.h>
+#include <uORB/topics/sees_manual_control_data.h>
 
 class MavlinkStreamSysStatus : public MavlinkStream
 {
@@ -64,12 +65,15 @@ private:
 	uORB::SubscriptionMultiArray<battery_status_s, battery_status_s::MAX_INSTANCES> _battery_status_subs{ORB_ID::battery_status};
 	uORB::Subscription _rc_channels_sub{ORB_ID(rc_channels)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	uORB::Subscription _sees_manual_control_data_sub{ORB_ID(sees_manual_control_data)};
 
 	bool send() override
 	{
 		if (_status_sub.updated() || _cpuload_sub.updated() || _battery_status_subs.updated()) {
 			vehicle_status_s status{};
 			_status_sub.copy(&status);
+			sees_manual_control_data_s sees_manual_control_data{};
+			_sees_manual_control_data_sub.copy(&sees_manual_control_data);
 
 			cpuload_s cpuload{};
 			_cpuload_sub.copy(&cpuload);
@@ -137,10 +141,11 @@ private:
 
 			msg.errors_count1 =
 				status.rc_signal_lost;    // No manual_control_setpoint messages arriving ( can come from RC or MAV )
-			msg.errors_count2 = status.data_link_lost;    // No messages from GCS received
+			msg.errors_count2 =
+				sees_manual_control_data.valid_mavlink_setpoint_count;    // Number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.
 			msg.errors_count3 = rc_channels.signal_lost;           // No messages from RC Tx received
 			msg.errors_count4 =
-				manual_control_setpoint.data_source;       // Indicates wether the drone is controlled by RC (1) or Mavlink (2-7)
+				sees_manual_control_data.sees_desired_control_source;       // Desired type of manual control source, RC (1) or Mav (2)
 
 			mavlink_msg_sys_status_send_struct(_mavlink->get_channel(), &msg);
 			return true;


### PR DESCRIPTION
TODO:
Several fixes including:
https://seesai.atlassian.net/browse/S1-4467
https://seesai.atlassian.net/browse/S1-4385
https://seesai.atlassian.net/browse/S1-4401
https://seesai.atlassian.net/browse/S1-3792

Additional improvements:
- Number of RC and Mav sources which are providing setpoints and are still alive is now logged (for Mav, this is any mavlink connection with a real or virtual joystick). This is passed to SI2 to monitor and flag where necessary.
- Removed additional enum in manual_control_setpoint.msg, alternative solution found as wasn't best practice.
