### PR TITLE
SI2 RC Connected Status Indicator Fix

### DIFF
--- a/src/modules/mavlink/streams/SYS_STATUS.hpp
+++ b/src/modules/mavlink/streams/SYS_STATUS.hpp
@@ -143,7 +143,8 @@ private:
 				status.rc_signal_lost;    // No manual_control_setpoint messages arriving ( can come from RC or MAV )
 			msg.errors_count2 =
 				sees_manual_control_data.valid_mavlink_setpoint_count;    // Number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.
-			msg.errors_count3 = rc_channels.signal_lost;           // No messages from RC Tx received
+			msg.errors_count3 =
+				sees_manual_control_data.valid_rc_setpoint_count;           // Number of RC connections providing setpoints (implying RC Connected). Should be < 2.
 			msg.errors_count4 =
 				sees_manual_control_data.sees_desired_control_source;       // Desired type of manual control source, RC (1) or Mavlink (2)
 


### PR DESCRIPTION
This PR is interlinked with the following SeesInterface2 and MAVSDK PRs:

- https://github.com/SEESAI/SeesInterface2/pull/631
- https://github.com/SEESAI/MAVSDK/pull/18

### Problem
This PR includes fixes and improvements for the following bug:
- https://seesai.atlassian.net/browse/S1-4689 - RC shown as connected when there is none present

SI2 looks at the signal_lost flag in the rc_channels uORB topic.
However, this flag is never initialised until an RC signal is found. I.e, RC signal must be found for it to ever be flagged as lost.

This means that if the RC Controller is never turned on (which is standard for BVLOS), then the signal lost flag will never trigger.

### Solution
Originally, SI2 looked at the signal_lost flag in the rc_channels uORB topic.
This PR now passes the valid_rc_setpoint_count instead, which indicates the number of (live) RC controllers connected (which should only ever really be 0 or 1).

Sees had already added this count in a previous PR for logging purposes.