### PR TITLE
New GPS data fields for better pose estimation

### DIFF
--- a/src/modules/mavlink/streams/GPS_INPUT.hpp
+++ b/src/modules/mavlink/streams/GPS_INPUT.hpp
@@ -82,6 +82,7 @@ private:
 				msg.horiz_accuracy = gps.eph;
 				msg.vert_accuracy = gps.epv;
 				msg.speed_accuracy = gps.s_variance_m_s;
+				msg.course_accuracy = gps.c_variance_rad;
 
 				if (PX4_ISFINITE(gps.heading)) {
 					if (fabsf(gps.heading) < FLT_EPSILON) {

--- a/src/modules/mavlink/streams/GPS_INPUT.hpp
+++ b/src/modules/mavlink/streams/GPS_INPUT.hpp
@@ -81,6 +81,7 @@ private:
 				msg.vd = gps.vel_d_m_s;
 				msg.horiz_accuracy = gps.eph;
 				msg.vert_accuracy = gps.epv;
+				msg.speed_accuracy = gps.s_variance_m_s;
 
 				if (PX4_ISFINITE(gps.heading)) {
 					if (fabsf(gps.heading) < FLT_EPSILON) {
@@ -88,6 +89,10 @@ private:
 
 					} else {
 						msg.yaw = math::degrees(matrix::wrap_2pi(gps.heading)) * 100.0f; // centidegrees
+					}
+
+					if (PX4_ISFINITE(gps.heading_accuracy)) {
+						msg.heading_accuracy = gps.heading_accuracy; // Heading / track uncertainty in radians
 					}
 				}
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
No uncertainties provided with yaw or velocity GPS measurements.

Fixes #{Github issue ID}

### Solution
- Added course and heading (yaw) accuracy fields to the mavlink GPS messages (speed accuracy was already there)

### Test coverage
- Worked on Whitby.