### PR TITLE
Fix MAVLink duplicate fields boogalo

### DIFF
--- a/src/modules/mavlink/streams/GPS_INPUT.hpp
+++ b/src/modules/mavlink/streams/GPS_INPUT.hpp
@@ -81,8 +81,6 @@ private:
 				msg.vd = gps.vel_d_m_s;
 				msg.horiz_accuracy = gps.eph;
 				msg.vert_accuracy = gps.epv;
-				msg.speed_accuracy = gps.s_variance_m_s;
-				msg.course_accuracy = gps.c_variance_rad;
 
 				if (PX4_ISFINITE(gps.heading)) {
 					if (fabsf(gps.heading) < FLT_EPSILON) {
@@ -90,10 +88,6 @@ private:
 
 					} else {
 						msg.yaw = math::degrees(matrix::wrap_2pi(gps.heading)) * 100.0f; // centidegrees
-					}
-
-					if (PX4_ISFINITE(gps.heading_accuracy)) {
-						msg.heading_accuracy = gps.heading_accuracy; // Heading / track uncertainty in radians
 					}
 				}
 

--- a/src/modules/mavlink/streams/GPS_INPUT.hpp
+++ b/src/modules/mavlink/streams/GPS_INPUT.hpp
@@ -81,6 +81,8 @@ private:
 				msg.vd = gps.vel_d_m_s;
 				msg.horiz_accuracy = gps.eph;
 				msg.vert_accuracy = gps.epv;
+				msg.speed_accuracy = gps.s_variance_m_s;
+				msg.course_accuracy = gps.c_variance_rad;
 
 				if (PX4_ISFINITE(gps.heading)) {
 					if (fabsf(gps.heading) < FLT_EPSILON) {
@@ -88,6 +90,10 @@ private:
 
 					} else {
 						msg.yaw = math::degrees(matrix::wrap_2pi(gps.heading)) * 100.0f; // centidegrees
+					}
+
+					if (PX4_ISFINITE(gps.heading_accuracy)) {
+						msg.heading_accuracy = gps.heading_accuracy; // Heading / track uncertainty in radians
 					}
 				}
 


### PR DESCRIPTION
### Problem
No uncertainties provided with yaw or velocity GPS measurements.

### Solution
Added course and heading (yaw) accuracy fields to the mavlink GPS messages (speed accuracy was already there)
