### PR TITLE
IRLock logging now default enabled

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -70,8 +70,8 @@ void LoggedTopics::add_default_topics()
 	add_topic("hover_thrust_estimate", 100);
 	add_topic("input_rc", 500);
 	add_optional_topic("internal_combustion_engine_status", 10);
-	add_optional_topic("irlock_report", 1000);
-	add_optional_topic("landing_target_pose", 1000);
+	add_topic("irlock_report", 250);				// Sees.ai - Changed from 'optional' topic and increased rate
+	add_topic("landing_target_pose", 250);				// Sees.ai - Changed from 'optional' topic and increased rate
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("magnetometer_noise", 200);				// Sees.ai - Added topic for monitoring mag disturbance/filter performance
 	add_topic("manual_control_setpoint", 200);


### PR DESCRIPTION
Title explains it well enough!

Note, MAVROS tests are failing as glibc2.28 can't be found on whatever environment these tests are being run on. Choosing to leave it as is for now with the intent to look into it.
Cannot run tests locally as they require ROS which would make life difficult.