### PR TITLE
Added yaw max acceleration param

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
@@ -41,7 +41,9 @@
 
 StickYaw::StickYaw()
 {
-	_yawspeed_slew_rate.setSlewRate(2.f * M_PI_F);
+	param_get(param_find("MC_YAW_ACC_MAX"), &_yaw_acc_max_deg);
+	_yaw_acc_max_rad = float(_yaw_acc_max_deg) * M_DEG_TO_RAD_F;
+	_yawspeed_slew_rate.setSlewRate(_yaw_acc_max_rad * M_PI_F);
 }
 
 void StickYaw::generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, const float desired_yawspeed,

--- a/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
@@ -41,9 +41,10 @@
 
 StickYaw::StickYaw()
 {
-	param_get(param_find("MC_YAW_ACC_MAX"), &_yaw_acc_max_deg);
-	_yaw_acc_max_rad = float(_yaw_acc_max_deg) * M_DEG_TO_RAD_F;
-	_yawspeed_slew_rate.setSlewRate(_yaw_acc_max_rad * M_PI_F);
+	int32_t yaw_acc_max_deg = 360;
+	param_get(param_find("MC_YAW_ACC_MAX"), &yaw_acc_max_deg);
+	float yaw_acc_max_rad = float(yaw_acc_max_deg) * M_DEG_TO_RAD_F;
+	_yawspeed_slew_rate.setSlewRate(yaw_acc_max_rad);
 }
 
 void StickYaw::generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, const float desired_yawspeed,

--- a/src/modules/flight_mode_manager/tasks/Utility/StickYaw.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickYaw.hpp
@@ -66,7 +66,4 @@ private:
 	 * @return yaw setpoint to execute to have a yaw lock at the correct moment in time
 	 */
 	static float updateYawLock(float yaw, float yawspeed_setpoint, float yaw_setpoint, bool is_yaw_good_for_control);
-
-	int32_t _yaw_acc_max_deg = 360;
-	float _yaw_acc_max_rad = 2 * M_PI_2_F;
 };

--- a/src/modules/flight_mode_manager/tasks/Utility/stick_yaw_params.c
+++ b/src/modules/flight_mode_manager/tasks/Utility/stick_yaw_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,41 +32,14 @@
  ****************************************************************************/
 
 /**
- * @file StickYaw.hpp
- * @brief Generate yaw and angular yawspeed setpoints from stick input
- * @author Matthias Grob <maetugr@gmail.com>
+ * Maximum yaw acceleration from stick input.
+ *
+ * In deg/s^2 (default 360)
+ * Added by sees.ai
+ *
+ * @reboot_required true
+ * @group Multicopter Attitude Control
+ * @unit deg/s
+ * @max 360
  */
-
-#pragma once
-
-#include "SlewRate.hpp"
-#include <parameters/param.h>
-
-class StickYaw
-{
-public:
-	StickYaw();
-	~StickYaw() = default;
-
-	void generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, float desired_yawspeed, float yaw,
-				 bool is_yaw_good_for_control, float deltatime);
-
-private:
-	SlewRate<float> _yawspeed_slew_rate;
-
-	/**
-	 * Lock yaw when not currently turning
-	 * When applying a yawspeed the vehicle is turning, when the speed is
-	 * set to zero the vehicle needs to slow down and then lock at the yaw
-	 * it stops at to not drift over time.
-	 * @param yawspeed current yaw rotational rate state
-	 * @param yaw current yaw rotational rate state
-	 * @param yawspeed_setpoint rotation rate at which to turn around yaw axis
-	 * @param yaw current yaw setpoint which then will be overwritten by the return value
-	 * @return yaw setpoint to execute to have a yaw lock at the correct moment in time
-	 */
-	static float updateYawLock(float yaw, float yawspeed_setpoint, float yaw_setpoint, bool is_yaw_good_for_control);
-
-	int32_t _yaw_acc_max_deg = 360;
-	float _yaw_acc_max_rad = 2 * M_PI_2_F;
-};
+PARAM_DEFINE_INT32(MC_YAW_ACC_MAX, 360);


### PR DESCRIPTION
### Problem
Relevant Jira bug https://seesai.atlassian.net/browse/S1-5075

PX4 yaw acceleration limit is hardcoded to 360deg/s^2.
This is too high for Yealm and can cause motor saturation.
### Solution
Yaw acceleration has been parameterised as MC_YAW_ACC_MAX with the default left at 360deg/s^2.
