### PR TITLE
Updating GPS submodule - F9P rate reduced to 7Hz, UART2 baud inc to 9…

### DIFF
--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -32,7 +32,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/compile_linux_arm64.yml
+++ b/.github/workflows/compile_linux_arm64.yml
@@ -29,7 +29,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -33,7 +33,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: macos_${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -88,7 +88,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -34,28 +34,28 @@ jobs:
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
-    - name: Prepare ccache timestamp
-      id: ccache_cache_timestamp
-      shell: cmake -P {0}
-      run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
-    - name: ccache cache files
-      uses: actions/cache@v4
-      with:
-        path: ~/.ccache
-        key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-        restore-keys: sitl_tests-${{matrix.config.build_type}}-ccache-
-    - name: setup ccache
-      run: |
-          mkdir -p ~/.ccache
-          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
-          echo "compression = true" >> ~/.ccache/ccache.conf
-          echo "compression_level = 6" >> ~/.ccache/ccache.conf
-          echo "max_size = 100M" >> ~/.ccache/ccache.conf
-          echo "hash_dir = false" >> ~/.ccache/ccache.conf
-          ccache -s
-          ccache -z
+    # - name: Prepare ccache timestamp
+    #   id: ccache_cache_timestamp
+    #   shell: cmake -P {0}
+    #   run: |
+    #     string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+    #     message("::set-output name=timestamp::${current_date}")
+    # # - name: ccache cache files
+    # #   uses: actions/cache@v4
+    # #   with:
+    # #     path: ~/.ccache
+    # #     key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+    # #     restore-keys: sitl_tests-${{matrix.config.build_type}}-ccache-
+    # # - name: setup ccache
+    # #   run: |
+    # #       mkdir -p ~/.ccache
+    # #       echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+    # #       echo "compression = true" >> ~/.ccache/ccache.conf
+    # #       echo "compression_level = 6" >> ~/.ccache/ccache.conf
+    # #       echo "max_size = 100M" >> ~/.ccache/ccache.conf
+    # #       echo "hash_dir = false" >> ~/.ccache/ccache.conf
+    # #       ccache -s
+    # #       ccache -z
 
     - name: check environment
       run: |

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
@@ -86,12 +86,12 @@ jobs:
     - name: Look at core files
       if: failure()
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
-    - name: Upload px4 coredump
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: coredump
-        path: px4.core
+    # - name: Upload px4 coredump
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: coredump
+    #     path: px4.core
 
     - name: ecl EKF analysis
       if: always()
@@ -101,26 +101,26 @@ jobs:
       if: always()
       run: ./Tools/upload_log.py -q --description "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID}" --feedback "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID} ${GITHUB_REPOSITORY} ${GITHUB_REF}" --source CI ~/.ros/log/*/*.ulg
 
-    - name: Upload px4 binary
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: binary
-        path: build/px4_sitl_default/bin/px4
+    # - name: Upload px4 binary
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: binary
+    #     path: build/px4_sitl_default/bin/px4
 
-    - name: Store PX4 log
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: px4_log
-        path: ~/.ros/log/*/*.ulg
+    # - name: Store PX4 log
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: px4_log
+    #     path: ~/.ros/log/*/*.ulg
 
-    - name: Store ROS log
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: ros_log
-        path: ~/.ros/**/rostest-*.log
+    # - name: Store ROS log
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: ros_log
+    #     path: ~/.ros/**/rostest-*.log
 
     # Report test coverage
     - name: Upload coverage

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -88,7 +88,7 @@ jobs:
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coredump
         path: px4.core
@@ -103,21 +103,21 @@ jobs:
 
     - name: Upload px4 binary
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binary
         path: build/px4_sitl_default/bin/px4
 
     - name: Store PX4 log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: px4_log
         path: ~/.ros/log/*/*.ulg
 
     - name: Store ROS log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ros_log
         path: ~/.ros/**/rostest-*.log

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -97,9 +97,9 @@ jobs:
       if: always()
       run: ./Tools/ecl_ekf/process_logdata_ekf.py ~/.ros/log/*/*.ulg || true
 
-    - name: Upload logs to flight review
-      if: always()
-      run: ./Tools/upload_log.py -q --description "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID}" --feedback "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID} ${GITHUB_REPOSITORY} ${GITHUB_REF}" --source CI ~/.ros/log/*/*.ulg
+    # - name: Upload logs to flight review
+    #   if: always()
+    #   run: ./Tools/upload_log.py -q --description "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID}" --feedback "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID} ${GITHUB_REPOSITORY} ${GITHUB_REF}" --source CI ~/.ros/log/*/*.ulg
 
     # - name: Upload px4 binary
     #   if: failure()

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -41,7 +41,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -78,44 +78,44 @@ jobs:
         ./test/rostest_px4_run.sh ${{matrix.config.test_file}} vehicle:=${{matrix.config.vehicle}}
       timeout-minutes: 45
 
-    - name: Look at core files
-      if: failure()
-      run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
-    - name: Upload px4 coredump
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: coredump
-        path: px4.core
+    # - name: Look at core files
+    #   if: failure()
+    #   run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
+    # - name: Upload px4 coredump
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: coredump
+    #     path: px4.core
 
-    - name: ecl EKF analysis
-      if: always()
-      run: ./Tools/ecl_ekf/process_logdata_ekf.py ~/.ros/log/*/*.ulg || true
+    # - name: ecl EKF analysis
+    #   if: always()
+    #   run: ./Tools/ecl_ekf/process_logdata_ekf.py ~/.ros/log/*/*.ulg || true
 
-    - name: Upload logs to flight review
-      if: always()
-      run: ./Tools/upload_log.py -q --description "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID}" --feedback "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID} ${GITHUB_REPOSITORY} ${GITHUB_REF}" --source CI ~/.ros/log/*/*.ulg
+    # - name: Upload logs to flight review
+    #   if: always()
+    #   run: ./Tools/upload_log.py -q --description "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID}" --feedback "${GITHUB_WORKFLOW} ${GITHUB_RUN_ID} ${GITHUB_REPOSITORY} ${GITHUB_REF}" --source CI ~/.ros/log/*/*.ulg
 
-    - name: Upload px4 binary
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: binary
-        path: build/px4_sitl_default/bin/px4
+    # - name: Upload px4 binary
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: binary
+    #     path: build/px4_sitl_default/bin/px4
 
-    - name: Store PX4 log
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: px4_log
-        path: ~/.ros/log/*/*.ulg
+    # - name: Store PX4 log
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: px4_log
+    #     path: ~/.ros/log/*/*.ulg
 
-    - name: Store ROS log
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: ros_log
-        path: ~/.ros/**/rostest-*.log
+    # - name: Store ROS log
+    #   if: failure()
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: ros_log
+    #     path: ~/.ros/**/rostest-*.log
 
     # Report test coverage
     - name: Upload coverage

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -83,7 +83,7 @@ jobs:
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coredump
         path: px4.core
@@ -98,21 +98,21 @@ jobs:
 
     - name: Upload px4 binary
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binary
         path: build/px4_sitl_default/bin/px4
 
     - name: Store PX4 log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: px4_log
         path: ~/.ros/log/*/*.ulg
 
     - name: Store ROS log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ros_log
         path: ~/.ros/**/rostest-*.log

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -36,7 +36,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -29,28 +29,28 @@ jobs:
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
-    - name: Prepare ccache timestamp
-      id: ccache_cache_timestamp
-      shell: cmake -P {0}
-      run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
-    - name: ccache cache files
-      uses: actions/cache@v4
-      with:
-        path: ~/.ccache
-        key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-        restore-keys: sitl_tests-${{matrix.config.build_type}}-ccache-
-    - name: setup ccache
-      run: |
-          mkdir -p ~/.ccache
-          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
-          echo "compression = true" >> ~/.ccache/ccache.conf
-          echo "compression_level = 6" >> ~/.ccache/ccache.conf
-          echo "max_size = 100M" >> ~/.ccache/ccache.conf
-          echo "hash_dir = false" >> ~/.ccache/ccache.conf
-          ccache -s
-          ccache -z
+    # - name: Prepare ccache timestamp
+    #   id: ccache_cache_timestamp
+    #   shell: cmake -P {0}
+    #   run: |
+    #     string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+    #     message("::set-output name=timestamp::${current_date}")
+    # - name: ccache cache files
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ~/.ccache
+    #     key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+    #     restore-keys: sitl_tests-${{matrix.config.build_type}}-ccache-
+    # - name: setup ccache
+    #   run: |
+    #       mkdir -p ~/.ccache
+    #       echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+    #       echo "compression = true" >> ~/.ccache/ccache.conf
+    #       echo "compression_level = 6" >> ~/.ccache/ccache.conf
+    #       echo "max_size = 100M" >> ~/.ccache/ccache.conf
+    #       echo "hash_dir = false" >> ~/.ccache/ccache.conf
+    #       ccache -s
+    #       ccache -z
 
     - name: check environment
       run: |

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -40,7 +40,7 @@ jobs:
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
         message("::set-output name=timestamp::${current_date}")
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: sitl_tests-${{matrix.config.build_type}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}


### PR DESCRIPTION
PX4 has been battling with F9P to try and force to poll at 8Hz, but it was struggling causing a lot of individual drops.
We have now reduced the rate in PX4 to 7Hz and it looks to have ironed it out significantly.

This gets fixed more gracefully in later PX4 GPS driver repo versions here (but is not yet in a release):
https://github.com/PX4/PX4-GPSDrivers/commit/bbdd5767a961cc17bdcc577c79b1c708d2a7999a#diff-1febc78d26e00434cf70e92631383f784fdb02aa7170afd41fb6eff90114d0b8

We've also upped UART2 baud rate (used for GPS Heading) to 921600 as the previous 460800 was recommended for 5Hz.

Also have updated some git workflow action versions, and commented out certain tests that require deprecated actions (such as actions/upload-artifact, see here https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/ ).
These tests were removed anyways in later PX4 versions here https://github.com/PX4/PX4-Autopilot/commit/28487350d3cd7e6730cec2773e99d9a652666d31