### PR TITLE
Geofence Predictive Behaviour 'Fixed'

### DIFF
--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -144,6 +144,7 @@ public:
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
+	bool getSeesStop() { return _param_gf_sees_stop.get();}
 
 	bool isHomeRequired();
 
@@ -223,6 +224,7 @@ private:
 		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,
 		(ParamFloat<px4::params::GF_MAX_HOR_DIST>) _param_gf_max_hor_dist,
 		(ParamFloat<px4::params::GF_MAX_VER_DIST>) _param_gf_max_ver_dist,
-		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict
+		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict,
+		(ParamBool<px4::params::GF_SEES_STOP>)	   _param_gf_sees_stop
 	)
 };

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -141,3 +141,16 @@ PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_PREDICT, 1);
+
+/**
+ * Brake and Hold upon geofence triggering (Sees)
+ *
+ * If set to True:
+ * When the Geofence is triggered, if the failsafe is set to Loiter (Hold) then brake and hold position at the stopping point.
+ * If set to False:
+ * Do PX4 default behaviour - set Loiter point based on GF_PREDICT param (either return to inside Geofence or trigger early and stop on Geofence)
+ *
+ * @boolean
+ * @group Geofence
+ */
+PARAM_DEFINE_INT32(GF_SEES_STOP, 0);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -849,12 +849,14 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 		if (_geofence.getPredict()) {
 			fence_violation_test_point = _gf_breach_avoidance.getFenceViolationTestPoint();
-			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning), "Approaching on geofence");
+			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning),
+				 "Approaching on geofence, test point dist = %lf", double(test_point_distance));
 
 		} else {
 			fence_violation_test_point = matrix::Vector2d(_global_pos.lat, _global_pos.lon);
 			vertical_test_point_distance = 0;
-			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning), "Geofence exceeded");
+			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning), "Geofence exceeded, test point dist = %lf",
+				 double(test_point_distance));
 		}
 
 		gf_violation_type.flags.dist_to_home_exceeded = !_geofence.isCloserThanMaxDistToHome(fence_violation_test_point(0),
@@ -894,36 +896,40 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 					matrix::Vector2<double> current_pos_lat_lon(_global_pos.lat, _global_pos.lon);
 					float loiter_altitude_amsl = _global_pos.alt;
 
+					// --- Sees.ai ---
+					// If we have the Sees stop param enabled, then skip the default PX4 behaviour of setting a specific setpoint location.
+					// Without a specific setpoint, when the drone switches to Loiter (Hold) it will brake and Hold at the stopping point.
+					if (!_geofence.getSeesStop()) {
+						if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+							// the computation of the braking distance does not match the actual braking distance. Until we have a better model
+							// we set the loiter point to the current position, that will make sure that the vehicle will loiter inside the fence
+							loiter_center_lat_lon =  _gf_breach_avoidance.generateLoiterPointForMultirotor(gf_violation_type,
+										 &_geofence);
 
-					if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-						// the computation of the braking distance does not match the actual braking distance. Until we have a better model
-						// we set the loiter point to the current position, that will make sure that the vehicle will loiter inside the fence
-						loiter_center_lat_lon =  _gf_breach_avoidance.generateLoiterPointForMultirotor(gf_violation_type,
-									 &_geofence);
+							loiter_altitude_amsl = _gf_breach_avoidance.generateLoiterAltitudeForMulticopter(gf_violation_type);
 
-						loiter_altitude_amsl = _gf_breach_avoidance.generateLoiterAltitudeForMulticopter(gf_violation_type);
+						} else {
 
-					} else {
+							loiter_center_lat_lon = _gf_breach_avoidance.generateLoiterPointForFixedWing(gf_violation_type, &_geofence);
+							loiter_altitude_amsl = _gf_breach_avoidance.generateLoiterAltitudeForFixedWing(gf_violation_type);
+						}
 
-						loiter_center_lat_lon = _gf_breach_avoidance.generateLoiterPointForFixedWing(gf_violation_type, &_geofence);
-						loiter_altitude_amsl = _gf_breach_avoidance.generateLoiterAltitudeForFixedWing(gf_violation_type);
+
+						rep->current.timestamp = hrt_absolute_time();
+						rep->current.yaw = get_local_position()->heading;
+						rep->current.yaw_valid = true;
+						rep->current.lat = loiter_center_lat_lon(0);
+						rep->current.lon = loiter_center_lat_lon(1);
+						rep->current.alt = loiter_altitude_amsl;
+						rep->current.valid = true;
+						rep->current.loiter_radius = get_loiter_radius();
+						rep->current.alt_valid = true;
+						rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+						rep->current.loiter_direction = 1;
+						rep->current.cruising_throttle = get_cruising_throttle();
+						rep->current.acceptance_radius = get_acceptance_radius();
+						rep->current.cruising_speed = get_cruising_speed();
 					}
-
-					rep->current.timestamp = hrt_absolute_time();
-					rep->current.yaw = get_local_position()->heading;
-					rep->current.yaw_valid = true;
-					rep->current.lat = loiter_center_lat_lon(0);
-					rep->current.lon = loiter_center_lat_lon(1);
-					rep->current.alt = loiter_altitude_amsl;
-					rep->current.valid = true;
-					rep->current.loiter_radius = get_loiter_radius();
-					rep->current.alt_valid = true;
-					rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
-					rep->current.loiter_direction = 1;
-					rep->current.cruising_throttle = get_cruising_throttle();
-					rep->current.acceptance_radius = get_acceptance_radius();
-					rep->current.cruising_speed = get_cruising_speed();
-
 				}
 
 				_geofence_violation_warning_sent = true;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -897,6 +897,8 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 					// --- Sees.ai ---
 					// If we have the Sees stop param enabled, then skip the default PX4 behaviour of setting a specific setpoint location.
 					// Without a specific setpoint, when the drone switches to Loiter (Hold) it will brake and Hold at the stopping point.
+					// This is because if the setpoint .valid isn't set to true, then Loiter will set a waypoint at the location + braking distance.
+					// See loiter.cpp
 					if (!_geofence.getSeesStop()) {
 						if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 							// the computation of the braking distance does not match the actual braking distance. Until we have a better model

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -849,14 +849,12 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 		if (_geofence.getPredict()) {
 			fence_violation_test_point = _gf_breach_avoidance.getFenceViolationTestPoint();
-			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning),
-				 "Approaching on geofence, test point dist = %lf", double(test_point_distance));
+			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning), "Approaching on geofence");
 
 		} else {
 			fence_violation_test_point = matrix::Vector2d(_global_pos.lat, _global_pos.lon);
 			vertical_test_point_distance = 0;
-			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning), "Geofence exceeded, test point dist = %lf",
-				 double(test_point_distance));
+			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning), "Geofence exceeded");
 		}
 
 		gf_violation_type.flags.dist_to_home_exceeded = !_geofence.isCloserThanMaxDistToHome(fence_violation_test_point(0),


### PR DESCRIPTION
### Problem
Vanilla PX4 1.13 will make use of inaccurate braking distance estimates to predict if a Geofence may be breached (based on its current position, trajectory and control limits).
It's bad enough that in SITL, the drone can trigger a breach ~50m inside the Geofence, consequently setting a Loiter point at that 50m distance (effectively on the Geofence). The drone then flies to this Loiter point blindly with no OA.

Turning off the 'Predictive' nature with GF_PREDICT = 0 doesn't help much either. The drone now triggers a breach when its position crosses the Geofence, however it will then overshoot the Geofence before flying back to the Geofence. Except, it then sets another loiter point at a random location that is X m (can't remember where or why this is set) further inside the geofence. This is better in the sense that the pilot will be certain of where the drone will trigger a breach and switch into a automated flight mode, and that it will return back in the geofence, but it is still alarming for the pilot as the drone is flying randomly and relies on the pilot deducing that it's a Geofence breach.

### Solution
This change introduces a new parameter; GF_SEES_STOP.

If we have the Sees stop param enabled, then it will skip the default PX4 behaviour of setting a specific setpoint location.
Without a specific setpoint, when the drone switches to Loiter (Hold) it will brake and Hold at the stopping point. This is because if the setpoint .valid isn't set to true, then Loiter will set a waypoint at the location + braking distance (see loiter.cpp).
If it's disabled, it will do PX4 default behaviour - set Loiter point based on GF_PREDICT param (either return to inside Geofence or trigger early and stop on Geofence)

Note - the stopping point will be outside of the Geofence by whatever distance the drone requires to come to a stop.