### PR TITLE
Adding params that identify Comp IDs for param management tool

### DIFF
--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -471,13 +471,13 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	}
 
 	// If compid_1 isn't set, then take the first CAN ID
-	if (_uavcan_compid_1 == -1){
+	if (_uavcan_compid_1 == -1) {
 		_uavcan_compid_1 = msg.getSrcNodeID().get();
 		param_set(param_find("UAVCAN_COMPID_1"), &_uavcan_compid_1);
 	}
 
 	// If compid_1 IS set, and compid_2 is not yet set AND this CAN ID does not match compid_1, then take this other CAN ID
-	if (_uavcan_compid_1 != -1 && _uavcan_compid_2 == -1 && msg.getSrcNodeID().get() != _uavcan_compid_1){
+	if (_uavcan_compid_1 != -1 && _uavcan_compid_2 == -1 && msg.getSrcNodeID().get() != _uavcan_compid_1) {
 		_uavcan_compid_2 = msg.getSrcNodeID().get();
 		param_set(param_find("UAVCAN_COMPID_2"), &_uavcan_compid_2);
 	}

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -145,9 +145,9 @@ private:
 	perf_counter_t _moving_baseline_data_pub_perf{nullptr};
 
 	// Sees.ai params for CAN and Param management
-	int32_t _gps_rover_can_id = -1;	// Initialised as -1 as the IDs are limited between 0-125
-	int32_t _uavcan_compid_1 = -1;	// Initialised as -1 as the IDs are limited between 0-125
-	int32_t _uavcan_compid_2 = -1;	// Initialised as -1 as the IDs are limited between 0-125
+	int32_t _gps_rover_can_id = -1;	// Initialised as -1 as the IDs decrement from 125
+	int32_t _uavcan_compid_1 = -1;	// Initialised as -1 as the IDs decrement from 125
+	int32_t _uavcan_compid_2 = -1;	// Initialised as -1 as the IDs decrement from 125
 	bool	_set_once = false; 	// Set params once on startup
 	hrt_abstime _last_warn = 0;
 };

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -144,6 +144,10 @@ private:
 	perf_counter_t _rtcm_stream_pub_perf{nullptr};
 	perf_counter_t _moving_baseline_data_pub_perf{nullptr};
 
-	int32_t _gps_rover_can_id = 126;	// Initialised as 126 as the IDs are limited between 0-125
+					// Sees.ai params for CAN and Param management
+	int32_t _gps_rover_can_id = -1;	// Initialised as -1 as the IDs are limited between 0-125
+	int32_t _uavcan_compid_1 = -1;	// Initialised as -1 as the IDs are limited between 0-125
+	int32_t _uavcan_compid_2 = -1;	// Initialised as -1 as the IDs are limited between 0-125
+	bool	_set_once = false; 	// Set params once on startup
 	hrt_abstime _last_warn = 0;
 };

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -144,7 +144,7 @@ private:
 	perf_counter_t _rtcm_stream_pub_perf{nullptr};
 	perf_counter_t _moving_baseline_data_pub_perf{nullptr};
 
-					// Sees.ai params for CAN and Param management
+	// Sees.ai params for CAN and Param management
 	int32_t _gps_rover_can_id = -1;	// Initialised as -1 as the IDs are limited between 0-125
 	int32_t _uavcan_compid_1 = -1;	// Initialised as -1 as the IDs are limited between 0-125
 	int32_t _uavcan_compid_2 = -1;	// Initialised as -1 as the IDs are limited between 0-125

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -382,3 +382,31 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_BTN, 0);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_ROVER_ID, 125);
+
+/**
+ * UAVCAN Component ID 1
+ *
+ * Added by sees.ai for Param Management system.
+ * Currently there is no other way to determine all CAN Nodes on a system which is required for getting and setting params robustly.
+ *
+ * @min 0
+ * @max 125
+ *
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_COMPID_1, 125);
+
+/**
+ * UAVCAN Component ID 2
+ *
+ * Added by sees.ai for Param Management system.
+ * Currently there is no other way to determine all CAN Nodes on a system which is required for getting and setting params robustly.
+ *
+ * @min 0
+ * @max 125
+ *
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_COMPID_2, 124);


### PR DESCRIPTION
### Problem
Mavsdk-python (along with several other mavlink tools) cannot determine all of the component IDs on a system. This makes it very difficult to retrieve all of the parameters on a system confidently or robustly.

### Solution
This adds 2 parameters:
- UAVCAN_COMPID_1
- UAVCAN_COMPID_2

These parameters are set to the IDs of up to 2 CAN GPS modules on the system on startup.
The Sees.ai parameter management tool is then able to use param_get() to read these values to determine the present component IDs.