### PR TITLE
Minor bug fix, UAVCAN_COMPID would default to 124 or 125 if no GPS attached

### DIFF
--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -389,13 +389,13 @@ PARAM_DEFINE_INT32(UAVCAN_ROVER_ID, 125);
  * Added by sees.ai for Param Management system.
  * Currently there is no other way to determine all CAN Nodes on a system which is required for getting and setting params robustly.
  *
- * @min 0
+ * @min -1
  * @max 125
  *
  * @reboot_required true
  * @group UAVCAN
  */
-PARAM_DEFINE_INT32(UAVCAN_COMPID_1, 125);
+PARAM_DEFINE_INT32(UAVCAN_COMPID_1, -1);
 
 /**
  * UAVCAN Component ID 2
@@ -403,10 +403,10 @@ PARAM_DEFINE_INT32(UAVCAN_COMPID_1, 125);
  * Added by sees.ai for Param Management system.
  * Currently there is no other way to determine all CAN Nodes on a system which is required for getting and setting params robustly.
  *
- * @min 0
+ * @min -1
  * @max 125
  *
  * @reboot_required true
  * @group UAVCAN
  */
-PARAM_DEFINE_INT32(UAVCAN_COMPID_2, 124);
+PARAM_DEFINE_INT32(UAVCAN_COMPID_2, -1);


### PR DESCRIPTION
UAVCAN_COMPID_1 and UAVCAN_COMPID_2 have default values of 124 and 125.
These are then set to -1 when initialising GPS modules, before then setting to whatever the GPS modules actually are.

However, if no GPS modules are present then the GPS stack will not initialise and thus never set to -1 if no GPS is present.

Therefore, we now initialise the params to -1 as default.