### PR TITLE
Exposing GPS noise_per_ms Metric to UAVCAN

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -63,3 +63,6 @@
 	path = src/modules/mavlink/mavlink
 	url = https://github.com/SEESAI/mavlink.git
 	branch = 3b52eac_dev
+[submodule "src/drivers/uavcan/libuavcan"]
+	path = src/drivers/uavcan/libuavcan
+	url = git@github.com:SEESAI/libuavcan.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "src/drivers/uavcan/libuavcan"]
-	path = src/drivers/uavcan/libuavcan
-	url = https://github.com/dronecan/libuavcan.git
-	branch = main
 [submodule "Tools/jMAVSim"]
 	path = Tools/jMAVSim
 	url = https://github.com/PX4/jMAVSim.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -63,3 +63,6 @@
 	path = src/modules/mavlink/mavlink
 	url = https://github.com/SEESAI/mavlink.git
 	branch = 3b52eac_dev
+[submodule "src/drivers/uavcan/libuavcan"]
+	path = src/drivers/uavcan/libuavcan
+	url = https://github.com/SEESAI/libuavcan.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -63,6 +63,3 @@
 	path = src/modules/mavlink/mavlink
 	url = https://github.com/SEESAI/mavlink.git
 	branch = 3b52eac_dev
-[submodule "src/drivers/uavcan/libuavcan"]
-	path = src/drivers/uavcan/libuavcan
-	url = git@github.com:SEESAI/libuavcan.git

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -452,6 +452,8 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	report.heading_offset = heading_offset;
 	report.heading_accuracy = heading_accuracy;
 
+	report.noise_per_ms = msg.noise_per_ms;
+
 	// ---sees.ai---
 	// CAN node IDs are persistent, however uorb instance numbering is not (i.e GPS 124 can initialise as uorb instance 0 or 1).
 	// To solve this, we've added a parameter that allows the user to specify the CAN ID that should be uorb instance 0 (Rover).

--- a/src/drivers/uavcannode/Publishers/GnssFix2.hpp
+++ b/src/drivers/uavcannode/Publishers/GnssFix2.hpp
@@ -140,6 +140,8 @@ public:
 				fix2.ecef_position_velocity.push_back(ecefpositionvelocity);
 			}
 
+			fix2.noise_per_ms = gps.noise_per_ms;
+
 			uavcan::Publisher<uavcan::equipment::gnss::Fix2>::broadcast(fix2);
 
 			// ensure callback is registered


### PR DESCRIPTION
This PR exposes the u-Blox `noise_per_ms` metric recorded in the serial driver to the UAVCAN side. Tested: https://www.notion.so/seesai/GPS-Noise-Logging-Testing-320f348e991880319c73fb314e2f916d and reviewed the PX4 logs in SeesAnalytics, the following output is an example of the `noise_per_ms`.

<img width="1901" height="968" alt="Screenshot from 2026-03-13 18-41-10" src="https://github.com/user-attachments/assets/cb7fdd9d-fdc4-45df-8338-a9dfeabef3ac" />

Corresponding PR: 
- https://github.com/SEESAI/DSDL/pull/1
- https://github.com/SEESAI/libuavcan/pull/1
